### PR TITLE
fix(cuda): support renamed CCCL attribute

### DIFF
--- a/nix/packages.nix
+++ b/nix/packages.nix
@@ -74,7 +74,8 @@ let
       (lib.getDev cuda_cudart) # cuda_runtime.h, driver_types.h, ...
       (lib.getLib cuda_cudart)
       (lib.getOutput "include" cuda_nvrtc) # nvrtc.h
-      (lib.getDev cuda_cccl) # cuda/std/*, thrust, cub
+      # The pinned nixpkgs still uses cuda_cccl; newer overrides expose cccl.
+      (lib.getDev (cudaPackages.cccl or cudaPackages.cuda_cccl)) # cuda/std/*, thrust, cub
       cuda_nvcc # bin/nvcc, nvvm/
     ];
   };


### PR DESCRIPTION
## Summary

- Prefer the renamed `cudaPackages.cccl` attribute when nixpkgs provides it.
- Fall back to `cudaPackages.cuda_cccl` for the current pinned nixpkgs revision.

## Context

Newer nixpkgs revisions renamed the CUDA package-set attribute from `cuda_cccl` to `cccl` and warn when the compatibility alias is evaluated. The nixpkgs revision pinned by this flake predates that rename and exposes only `cuda_cccl`, so a direct rename would break the default flake.

The attribute fallback is lazy. The pinned input evaluates the old name, while newer input overrides evaluate the new name without triggering the deprecation warning.

## Verification

- `nix fmt nix/packages.nix`
- `nix flake check --accept-flake-config --no-build`
- Evaluated `packages.x86_64-linux.cuda` with the pinned nixpkgs input.
- Evaluated it with nixpkgs `65179426c83bb3f6bc14898b42ea1c6f01d374b0`; no `cuda_cccl` deprecation warning was emitted.
- Compared the downstream laptop service package before and after the change; both resolve to `/nix/store/0jn7h1kx8wx2gwx0s9640zrhpjibx0bs-comfy-ui-0.32.0.drv`.
