### PR TITLE
fix: container startup, torchsde build failure, and bundled node opt-out

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `getpass.getuser()`, and the Docker images gained `fakeNss` plus `USER`/
   `LOGNAME` so uid 0 resolves to a name.
   ([#41](https://github.com/utensils/comfyui-nix/issues/41))
+- `nixos-rebuild` no longer fails on torchsde's statistical
+  `test_normality_conditional`, which asserts a p-value above a threshold that
+  borderline draws fall under. Its test suite is disabled, also removing about
+  3.5 minutes from every build.
+  ([#91](https://github.com/utensils/comfyui-nix/issues/91))
 
 ### Changed
 - Updated ComfyUI to upstream `v0.32.0` (from `v0.30.2`), with the vendored

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- ComfyUI no longer crashes at startup in containers with
+  `KeyError: 'getpwuid(): uid not found: 0'`. The launcher now sets
+  `TORCHINDUCTOR_CACHE_DIR`, which stops torch from deriving a cache path from
+  `getpass.getuser()`, and the Docker images gained `fakeNss` plus `USER`/
+  `LOGNAME` so uid 0 resolves to a name.
+  ([#41](https://github.com/utensils/comfyui-nix/issues/41))
+
 ### Changed
 - Updated ComfyUI to upstream `v0.32.0` (from `v0.30.2`), with the vendored
   wheels it pins: frontend `1.48.7`, workflow templates `0.11.39`,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- `services.comfyui.bundledCustomNodes` (and the `COMFY_SKIP_BUNDLED_NODES=1`
+  environment variable it sets) to leave `custom_nodes/` under your own
+  management. With the bundled set enabled the launcher deletes any real
+  directory sharing a bundled node's name, which destroyed checkouts installed
+  through ComfyUI-Manager or git. The project's own `model_downloader` node is
+  still linked when opted out, since nothing else provides its API routes.
+  ([#92](https://github.com/utensils/comfyui-nix/issues/92))
+
 ### Fixed
 - ComfyUI no longer crashes at startup in containers with
   `KeyError: 'getpwuid(): uid not found: 0'`. The launcher now sets

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -117,7 +117,7 @@ The launcher does significant work beyond just starting ComfyUI:
 **Environment variables set by launcher** (important for debugging):
 
 - `COMFYUI_BASE_DIR`, `COMFYUI_MODEL_PATH` — prevent custom nodes from writing to Nix store
-- `TORCH_HOME`, `HF_HOME`, `FACEXLIB_MODELPATH` — redirect cache/model downloads into data dir
+- `TORCH_HOME`, `HF_HOME`, `FACEXLIB_MODELPATH`, `TORCHINDUCTOR_CACHE_DIR` — redirect cache/model downloads into data dir (`TORCHINDUCTOR_CACHE_DIR` also avoids torch's `getpass.getuser()` fallback, which crashes in containers with no passwd entry)
 - `VIRTUAL_ENV`, `PIP_TARGET` — for Manager package installs into `.venv`
 - `COMFY_VENV_PRECEDENCE` — set to `prefer-venv` to let venv packages override Nix packages (default: Nix takes precedence)
 - `LD_LIBRARY_PATH` (Linux) / `DYLD_LIBRARY_PATH` (macOS) — set automatically for system libraries

--- a/README.md
+++ b/README.md
@@ -202,6 +202,15 @@ Some custom nodes have hardcoded paths that don't exist on NixOS. We automatical
 
 The following custom nodes are bundled and automatically linked on first run:
 
+To manage `custom_nodes/` yourself instead — through ComfyUI-Manager, git
+clones, or `services.comfyui.customNodes` — set `COMFY_SKIP_BUNDLED_NODES=1`
+(`services.comfyui.bundledCustomNodes = false` on NixOS). The third-party nodes
+below are then left unlinked, and links from a previous run are removed.
+Model Downloader stays linked either way: it is this project's own node and
+provides the API endpoints below. Note that with the bundled set enabled the
+launcher deletes any real directory in `custom_nodes/` whose name matches one
+of these nodes.
+
 ### Model Downloader
 
 A non-blocking async download node with WebSocket progress updates. Download models directly within ComfyUI without blocking the UI.
@@ -447,6 +456,7 @@ nix profile add github:utensils/comfyui-nix#xpu
 | `environment`   | `{}`                 | Environment variables for the service            |
 | `extraPythonPackages` | `null`          | Extra declarative Python dependencies             |
 | `customNodes`   | `{}`                 | Declarative custom nodes (see below)             |
+| `bundledCustomNodes` | `true`          | Link the bundled custom nodes into `custom_nodes/` |
 | `requiresMounts`| `[]`                 | Mount units to wait for before starting          |
 
 `cudaCapabilities` maps to `nixpkgs.config.cudaCapabilities`, so setting it will
@@ -480,11 +490,11 @@ services.comfyui = {
   enable = true;
   customNodes = {
     # Fetch from GitHub (pinned version)
-    ComfyUI-Impact-Pack = pkgs.fetchFromGitHub {
-      owner = "ltdrdata";
-      repo = "ComfyUI-Impact-Pack";
+    comfyui_controlnet_aux = pkgs.fetchFromGitHub {
+      owner = "Fannovel16";
+      repo = "comfyui_controlnet_aux";
       rev = "v1.0.0";
-      hash = "sha256-...";  # nix-prefetch-github ltdrdata ComfyUI-Impact-Pack --rev v1.0.0
+      hash = "sha256-...";  # nix-prefetch-github Fannovel16 comfyui_controlnet_aux --rev v1.0.0
     };
     # Local path (for development)
     my-node = /path/to/node;
@@ -493,6 +503,12 @@ services.comfyui = {
 ```
 
 Nodes are symlinked at service start. This is the pure Nix approach - fully reproducible and version-pinned.
+
+Pick names that do not collide with the [bundled nodes](#bundled-custom-nodes).
+The launcher relinks those on every start, so an entry named after one of them
+(`ComfyUI-Impact-Pack`, `ComfyUI-KJNodes`, ...) is overwritten before ComfyUI
+reads it. To override a bundled node with your own pin, also set
+`bundledCustomNodes = false`.
 
 Custom nodes with additional Python dependencies can extend the selected
 CPU/CUDA/ROCm/XPU runtime declaratively:

--- a/nix/docker.nix
+++ b/nix/docker.nix
@@ -19,6 +19,12 @@
       useCpu = gpuSupport == "none";
       baseEnv = [
         "HOME=/root"
+        # Python's getpass.getuser() reads these before consulting the passwd
+        # database. fakeNss below covers callers that go to pwd.getpwuid()
+        # directly; between them uid 0 resolves to a name either way.
+        # See: https://github.com/utensils/comfyui-nix/issues/41
+        "USER=root"
+        "LOGNAME=root"
         "COMFY_USER_DIR=/data"
         "TMPDIR=/tmp"
         "PATH=/bin:/usr/bin"
@@ -68,6 +74,9 @@
       copyToRoot = pkgs.buildEnv {
         name = "comfy-ui-root";
         paths = [
+          # /etc/passwd + /etc/group for uid 0. Without them anything reaching
+          # pwd.getpwuid() raises "uid not found" inside the container.
+          pkgs.dockerTools.fakeNss
           pkgs.bash
           pkgs.coreutils
           pkgs.netcat

--- a/nix/modules/comfyui.nix
+++ b/nix/modules/comfyui.nix
@@ -40,7 +40,10 @@ let
   ]
   ++ lib.optional cfg.enableManager "--enable-manager"
   ++ cfg.extraArgs;
-  env = cfg.environment;
+  # The launcher reads COMFY_SKIP_BUNDLED_NODES; cfg.environment still wins so a
+  # user can override it explicitly.
+  env =
+    lib.optionalAttrs (!cfg.bundledCustomNodes) { COMFY_SKIP_BUNDLED_NODES = "1"; } // cfg.environment;
   escapedArgs = lib.concatStringsSep " " (map lib.escapeShellArg args);
   execStart = "${effectivePackage}/bin/comfy-ui ${escapedArgs}";
 
@@ -319,6 +322,29 @@ in
           # Or reference a pre-packaged node (future)
           # controlnet-aux = comfyui-nix.customNodes.controlnet-aux;
         }
+      '';
+    };
+
+    bundledCustomNodes = lib.mkOption {
+      type = lib.types.bool;
+      default = true;
+      description = ''
+        Whether to symlink the third-party custom nodes bundled with this
+        package (Impact Pack, KJNodes, GGUF, rgthree, PuLID, and friends) into
+        custom_nodes/ at service start. The project's own model_downloader node
+        is linked either way, since it provides API routes nothing else serves.
+
+        Set to false to leave custom_nodes/ entirely under your own control,
+        managed through ComfyUI-Manager, direct git clones, or the
+        services.comfyui.customNodes option. With this enabled the launcher
+        deletes any real directory whose name collides with a bundled node,
+        which destroys a checkout you installed by other means, and its
+        symlinks overwrite a services.comfyui.customNodes entry declared under
+        one of those names.
+
+        Disabling this removes the symlinks pointing at this build's bundled
+        nodes. Directories you own, and customNodes entries you declared, are
+        left alone.
       '';
     };
 

--- a/nix/packages.nix
+++ b/nix/packages.nix
@@ -509,43 +509,114 @@ let
               fi
             fi
 
-            # Link our bundled custom nodes
-            # Remove stale directories if they exist but aren't symlinks
-            for node_dir in "model_downloader" "ComfyUI-Impact-Pack" "rgthree-comfy" "ComfyUI-KJNodes" "ComfyUI-GGUF" "ComfyUI-LTXVideo" "ComfyUI-Florence2" "ComfyUI_bitsandbytes_NF4" "x-flux-comfyui" "ComfyUI-MMAudio" "PuLID_ComfyUI" "ComfyUI-WanVideoWrapper"; do
-              if [[ -e "$BASE_DIR/custom_nodes/$node_dir" && ! -L "$BASE_DIR/custom_nodes/$node_dir" ]]; then
-                rm -rf "$BASE_DIR/custom_nodes/$node_dir"
-              fi
-            done
-
-            # On macOS, remove Linux-only nodes if they were linked previously
-            # Note: PuLID now works on macOS via CoreML (insightface override removes mxnet dependency)
-            if [[ "$(uname)" == "Darwin" ]]; then
-              rm -f "$BASE_DIR/custom_nodes/ComfyUI_bitsandbytes_NF4" 2>/dev/null || true
+            # model_downloader is this project's own node, not a third-party
+            # bundle: it registers the /model-downloader API routes and its web
+            # extension, and nothing else provides them. It stays linked even
+            # when the third-party bundle is opted out, so opting out never
+            # silently removes part of this package's own API surface.
+            if [[ -e "$BASE_DIR/custom_nodes/model_downloader" && ! -L "$BASE_DIR/custom_nodes/model_downloader" ]]; then
+              rm -rf "$BASE_DIR/custom_nodes/model_downloader"
             fi
+            ln -sfn "${modelDownloaderDir}" "$BASE_DIR/custom_nodes/model_downloader"
+
+            # The third-party custom nodes this package bundles, as
+            # name=store-path pairs. The paths let the opt-out path below
+            # recognise its own symlinks instead of every link that happens to
+            # point into the store.
+            BUNDLED_NODES=(
+              "ComfyUI-Impact-Pack=${customNodes.impact-pack}"
+              "rgthree-comfy=${customNodes.rgthree-comfy}"
+              "ComfyUI-KJNodes=${customNodes.kjnodes}"
+              "ComfyUI-GGUF=${customNodes.gguf}"
+              "ComfyUI-LTXVideo=${customNodes.ltxvideo}"
+              "ComfyUI-Florence2=${customNodes.florence2}"
+              "ComfyUI_bitsandbytes_NF4=${customNodes.bitsandbytes-nf4}"
+              "x-flux-comfyui=${customNodes.x-flux}"
+              "ComfyUI-MMAudio=${customNodes.mmaudio}"
+              "PuLID_ComfyUI=${customNodes.pulid}"
+              "ComfyUI-WanVideoWrapper=${customNodes.wanvideo}"
+            )
 
             # Clean up stale read-only web extension directories (from Nix store)
             if [[ -d "$BASE_DIR/web/extensions" ]]; then
               find "$BASE_DIR/web/extensions" -maxdepth 1 -type d ! -writable -exec rm -rf {} \; 2>/dev/null || true
             fi
 
-            # Link bundled nodes (always update symlinks to pick up new Nix store paths)
-            ln -sfn "${modelDownloaderDir}" "$BASE_DIR/custom_nodes/model_downloader"
-            ln -sfn "${customNodes.impact-pack}" "$BASE_DIR/custom_nodes/ComfyUI-Impact-Pack"
-            ln -sfn "${customNodes.rgthree-comfy}" "$BASE_DIR/custom_nodes/rgthree-comfy"
-            ln -sfn "${customNodes.kjnodes}" "$BASE_DIR/custom_nodes/ComfyUI-KJNodes"
-            ln -sfn "${customNodes.gguf}" "$BASE_DIR/custom_nodes/ComfyUI-GGUF"
-            ln -sfn "${customNodes.ltxvideo}" "$BASE_DIR/custom_nodes/ComfyUI-LTXVideo"
-            ln -sfn "${customNodes.florence2}" "$BASE_DIR/custom_nodes/ComfyUI-Florence2"
-            # bitsandbytes requires CUDA (Linux-only)
-            if [[ "$(uname)" != "Darwin" ]]; then
-              ln -sfn "${customNodes.bitsandbytes-nf4}" "$BASE_DIR/custom_nodes/ComfyUI_bitsandbytes_NF4"
+            # Records the links the last managed start actually created, so the
+            # opt-out path can still recognise them after a version bump has
+            # moved every bundled node to a new store path.
+            BUNDLED_STATE="$BASE_DIR/custom_nodes/.comfy-bundled"
+
+            if [[ "''${COMFY_SKIP_BUNDLED_NODES:-0}" == "1" ]]; then
+              # Opt-out: leave custom_nodes to ComfyUI-Manager, manual git clones, or
+              # the NixOS module's `customNodes` option. Remove only links whose
+              # target we recognise as one of our own, either from this build or
+              # from the state file. Matching the exact path rather than
+              # /nix/store/* matters: the module's customNodes symlinks also point
+              # into the store, and a loose match would delete a node the user
+              # declared under a bundled name. A node declared at the exact
+              # derivation we bundle is indistinguishable from our own link and
+              # does get removed.
+              # See: https://github.com/utensils/comfyui-nix/issues/92
+              known_links=("''${BUNDLED_NODES[@]}")
+              if [[ -f "$BUNDLED_STATE" ]]; then
+                while IFS= read -r recorded; do
+                  [[ -n "$recorded" ]] && known_links+=("$recorded")
+                done < "$BUNDLED_STATE"
+              fi
+              for entry in "''${known_links[@]}"; do
+                node_path="$BASE_DIR/custom_nodes/''${entry%%=*}"
+                if [[ -L "$node_path" && "$(readlink "$node_path")" == "''${entry#*=}" ]]; then
+                  rm -f "$node_path"
+                fi
+              done
+              rm -f "$BUNDLED_STATE"
+              echo "COMFY_SKIP_BUNDLED_NODES=1: not managing bundled custom nodes"
+            else
+              # Link our bundled custom nodes
+              # Remove stale directories if they exist but aren't symlinks
+              for entry in "''${BUNDLED_NODES[@]}"; do
+                node_dir="''${entry%%=*}"
+                if [[ -e "$BASE_DIR/custom_nodes/$node_dir" && ! -L "$BASE_DIR/custom_nodes/$node_dir" ]]; then
+                  rm -rf "$BASE_DIR/custom_nodes/$node_dir"
+                fi
+              done
+
+              # On macOS, remove Linux-only nodes if they were linked previously
+              # Note: PuLID now works on macOS via CoreML (insightface override removes mxnet dependency)
+              if [[ "$(uname)" == "Darwin" ]]; then
+                rm -f "$BASE_DIR/custom_nodes/ComfyUI_bitsandbytes_NF4" 2>/dev/null || true
+              fi
+
+              # Link bundled nodes (always update symlinks to pick up new Nix store paths)
+              ln -sfn "${customNodes.impact-pack}" "$BASE_DIR/custom_nodes/ComfyUI-Impact-Pack"
+              ln -sfn "${customNodes.rgthree-comfy}" "$BASE_DIR/custom_nodes/rgthree-comfy"
+              ln -sfn "${customNodes.kjnodes}" "$BASE_DIR/custom_nodes/ComfyUI-KJNodes"
+              ln -sfn "${customNodes.gguf}" "$BASE_DIR/custom_nodes/ComfyUI-GGUF"
+              ln -sfn "${customNodes.ltxvideo}" "$BASE_DIR/custom_nodes/ComfyUI-LTXVideo"
+              ln -sfn "${customNodes.florence2}" "$BASE_DIR/custom_nodes/ComfyUI-Florence2"
+              # bitsandbytes requires CUDA (Linux-only)
+              if [[ "$(uname)" != "Darwin" ]]; then
+                ln -sfn "${customNodes.bitsandbytes-nf4}" "$BASE_DIR/custom_nodes/ComfyUI_bitsandbytes_NF4"
+              fi
+              ln -sfn "${customNodes.x-flux}" "$BASE_DIR/custom_nodes/x-flux-comfyui"
+              ln -sfn "${customNodes.mmaudio}" "$BASE_DIR/custom_nodes/ComfyUI-MMAudio"
+              # PuLID - face ID for consistent face generation
+              # Works on all platforms: Linux uses CUDA, macOS uses CoreML via onnxruntime
+              ln -sfn "${customNodes.pulid}" "$BASE_DIR/custom_nodes/PuLID_ComfyUI"
+              ln -sfn "${customNodes.wanvideo}" "$BASE_DIR/custom_nodes/ComfyUI-WanVideoWrapper"
+
+              # Record what we actually linked, so a later opt-out can find these
+              # links again even once a version bump has changed every path.
+              : > "$BUNDLED_STATE"
+              for entry in "''${BUNDLED_NODES[@]}"; do
+                node_dir="''${entry%%=*}"
+                node_path="$BASE_DIR/custom_nodes/$node_dir"
+                if [[ -L "$node_path" ]]; then
+                  printf '%s=%s\n' "$node_dir" "$(readlink "$node_path")" >> "$BUNDLED_STATE"
+                fi
+              done
             fi
-            ln -sfn "${customNodes.x-flux}" "$BASE_DIR/custom_nodes/x-flux-comfyui"
-            ln -sfn "${customNodes.mmaudio}" "$BASE_DIR/custom_nodes/ComfyUI-MMAudio"
-            # PuLID - face ID for consistent face generation
-            # Works on all platforms: Linux uses CUDA, macOS uses CoreML via onnxruntime
-            ln -sfn "${customNodes.pulid}" "$BASE_DIR/custom_nodes/PuLID_ComfyUI"
-            ln -sfn "${customNodes.wanvideo}" "$BASE_DIR/custom_nodes/ComfyUI-WanVideoWrapper"
 
             # Create default ComfyUI-Manager config if it doesn't exist
             # Note: Manager moved config from user/default/ComfyUI-Manager to user/__manager
@@ -664,7 +735,6 @@ let
             # passwd entry for the running uid. Setting it here also keeps the
             # JIT cache out of /tmp so it survives restarts.
             # See: https://github.com/utensils/comfyui-nix/issues/41
-            #
             # Unlike the caches above this one honours a caller-supplied value,
             # so a path we cannot create must not abort startup under set -e:
             # torch's own cache_dir() calls makedirs and reports it better.

--- a/nix/packages.nix
+++ b/nix/packages.nix
@@ -657,6 +657,20 @@ let
             export FACEXLIB_MODELPATH="$BASE_DIR/.cache/facexlib"
             mkdir -p "$FACEXLIB_MODELPATH/facexlib/weights"
 
+            # Redirect TorchInductor/Triton compile caches to the data directory.
+            # torch._dynamo resolves this at import time; when unset it falls back
+            # to /tmp/torchinductor_$(getpass.getuser()), which raises
+            # "KeyError: getpwuid(): uid not found" in containers that have no
+            # passwd entry for the running uid. Setting it here also keeps the
+            # JIT cache out of /tmp so it survives restarts.
+            # See: https://github.com/utensils/comfyui-nix/issues/41
+            #
+            # Unlike the caches above this one honours a caller-supplied value,
+            # so a path we cannot create must not abort startup under set -e:
+            # torch's own cache_dir() calls makedirs and reports it better.
+            export TORCHINDUCTOR_CACHE_DIR="''${TORCHINDUCTOR_CACHE_DIR:-$BASE_DIR/.cache/torchinductor}"
+            mkdir -p "$TORCHINDUCTOR_CACHE_DIR" || true
+
       ${lib.optionalString useCuda ''
         # =====================================================================
         # Runtime CUDA kernel compilation (NVRTC)

--- a/nix/python-overrides.nix
+++ b/nix/python-overrides.nix
@@ -971,6 +971,19 @@ lib.optionalAttrs useCuda {
   });
 }
 
+# torchsde's test suite costs ~3.5 minutes of every build of this flake, and it
+# is statistical rather than functional: test_normality_conditional asserts a
+# Kolmogorov-Smirnov p-value stays above 1e-5, so a borderline draw lands under
+# it and fails the whole nixos-rebuild for an unrelated reason. Dropping the
+# suite rather than just that test buys back the build time; pythonImportsCheck
+# still runs, and ComfyUI only uses torchsde's samplers.
+# See: https://github.com/utensils/comfyui-nix/issues/91
+// lib.optionalAttrs (prev ? torchsde) {
+  torchsde = prev.torchsde.overridePythonAttrs (_old: {
+    doCheck = false;
+  });
+}
+
 # Disable filterpy tests on Darwin (test_hinfinity triggers BPT trap in pytest)
 // lib.optionalAttrs (prev ? filterpy) {
   filterpy = prev.filterpy.overridePythonAttrs (old: {


### PR DESCRIPTION
Three independent fixes, one commit each. Closes #41, #91, #92.

**Merge note:** squash-merging collapses the three commits into one. Use a rebase merge to keep them separate, or squash if a single commit is preferred.

## fix: start cleanly in containers without a passwd entry (#41)

`torch._dynamo` resolves its inductor cache directory at import time, and with `TORCHINDUCTOR_CACHE_DIR` unset it derives one from `getpass.getuser()`. Nix container images carry no `/etc/passwd`, so that falls through to `pwd.getpwuid()` and raises `KeyError: 'getpwuid(): uid not found: 0'` before ComfyUI starts.

The launcher now sets the variable, which skips the `getuser()` path entirely and also keeps the JIT cache in the data directory instead of `/tmp`. The Docker images additionally get `dockerTools.fakeNss` plus `USER`/`LOGNAME`, so uid 0 resolves to a name for the other callers that ask.

Reproduced and verified: with `getpass.getuser` patched to raise, `import torch._dynamo.package` fails with the exact reported `KeyError` when the variable is unset, and imports cleanly when it is set. `/etc/passwd` confirmed present in the built image with a uid 0 entry.

## fix: stop torchsde's statistical test from failing the build (#91)

nixpkgs runs torchsde's suite on every build of this flake. `test_normality_conditional` asserts a Kolmogorov-Smirnov p-value stays above `1e-5`; a borderline draw lands just under and takes the whole `nixos-rebuild` down for an unrelated reason.

Disabling the suite rather than just that test also buys back the ~3.5 minutes it costs each build. Verified the derivation now has `doInstallCheck=""` with no pytest hook, while `pythonImportsCheck` still runs.

## feat: let users opt out of the bundled custom nodes (#92)

The launcher relinks its bundled nodes on every start and deletes any real directory sharing one of their names, so a checkout installed through ComfyUI-Manager or git was destroyed on each run, with no way to turn it off.

Adds `COMFY_SKIP_BUNDLED_NODES=1`, exposed on NixOS as `services.comfyui.bundledCustomNodes = false`.

Two subtleties worth reviewing:

- Cleanup matches the **exact store paths** the launcher linked, not any `/nix/store` target. A loose match would delete a node the user declared via `services.comfyui.customNodes` under a bundled name — exactly the workflow the issue asks for.
- A **state file** records what the last managed start linked, so those links are still recognised after a version bump has moved every bundled node to a new path. Without it, upgrading and opting out in the same rebuild would leave every bundled node still linked and loading.

`model_downloader` stays linked either way: it is this project's own node and serves API routes nothing else provides.

## Verification

- All four repo checks pass (ruff, pyright, shellcheck, nixfmt); all four package variants evaluate.
- The launcher was run against scratch data dirs covering the default path, a user's real clone, a user's own symlink, a declarative store symlink under a bundled name, and a simulated version bump. ComfyUI started in every case.
- The three commits were split from a single verified tree; the final build is bit-identical to the artifact that was functionally tested.