### PR TITLE
ci: let python-runtime-deps push to cachix

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -62,6 +62,8 @@ jobs:
   # enabled. Remove the override once the flake follows this revision or newer.
   python-runtime-deps:
     runs-on: ubuntu-latest
+    env:
+      CACHIX_AUTH_TOKEN: ${{ secrets.CACHIX_AUTH_TOKEN }}
     # One backend per job: a single runner cannot hold three GPU torch closures.
     strategy:
       fail-fast: false
@@ -91,10 +93,16 @@ jobs:
             experimental-features = nix-command flakes
             accept-flake-config = true
 
+      # Push realized store paths so subsequent runs (and this job across
+      # nixpkgs pin bumps) substitute instead of recompiling the whole
+      # unfree CUDA/ROCm/XPU stack from scratch. Same conditional-pushFilter
+      # pattern as `extra-python-packages` and `build`: fork PRs get no
+      # secret, so they fall back to read-only.
       - uses: cachix/cachix-action@v14
         with:
           name: comfyui
-          pushFilter: "-"
+          authToken: ${{ env.CACHIX_AUTH_TOKEN }}
+          pushFilter: ${{ env.CACHIX_AUTH_TOKEN && '' || '-' }}
 
       - uses: cachix/cachix-action@v14
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -95,14 +95,12 @@ jobs:
 
       # Push realized store paths so subsequent runs (and this job across
       # nixpkgs pin bumps) substitute instead of recompiling the whole
-      # unfree CUDA/ROCm/XPU stack from scratch. Same conditional-pushFilter
-      # pattern as `extra-python-packages` and `build`: fork PRs get no
-      # secret, so they fall back to read-only.
+      # unfree CUDA/ROCm/XPU stack from scratch. Fork PRs get no secret, so
+      # cachix-action falls back to read-only on an empty authToken.
       - uses: cachix/cachix-action@v14
         with:
           name: comfyui
           authToken: ${{ env.CACHIX_AUTH_TOKEN }}
-          pushFilter: ${{ env.CACHIX_AUTH_TOKEN && '' || '-' }}
 
       - uses: cachix/cachix-action@v14
         with:
@@ -158,13 +156,12 @@ jobs:
             accept-flake-config = true
 
       # Push the backend Torch closures so the `check` job below substitutes them
-      # instead of recompiling. Same conditional-pushFilter pattern as the `build`
-      # job: fork PRs get no secret, so they fall back to read-only.
+      # instead of recompiling. Fork PRs get no secret, so cachix-action falls
+      # back to read-only on an empty authToken.
       - uses: cachix/cachix-action@v14
         with:
           name: comfyui
           authToken: ${{ env.CACHIX_AUTH_TOKEN }}
-          pushFilter: ${{ env.CACHIX_AUTH_TOKEN && '' || '-' }}
 
       - uses: cachix/cachix-action@v14
         with:
@@ -314,7 +311,6 @@ jobs:
         with:
           name: comfyui
           authToken: ${{ env.CACHIX_AUTH_TOKEN }}
-          pushFilter: ${{ env.CACHIX_AUTH_TOKEN && '' || '-' }}
 
       # Pull from nix-community cache (has CUDA packages)
       - name: Configure Cachix (nix-community)


### PR DESCRIPTION
Closes #94.

## What

- Add job-level `CACHIX_AUTH_TOKEN` env to `python-runtime-deps` and give its `comfyui` cachix step an `authToken`, mirroring `extra-python-packages` and `build`. The job can now seed the cache it depends on instead of recompiling the unfree CUDA/ROCm/XPU stack from scratch every run until the 6-hour kill.
- Drop the `pushFilter: ${{ env.CACHIX_AUTH_TOKEN && '' || '-' }}` expression from all three `comfyui` cachix steps: `''` is falsy in Actions expressions so the ternary always evaluated to `-`, and cachix-action's daemon mode ignores `pushFilter` entirely. The default (push everything) is the intended behavior and also covers the non-daemon fallback path.

## Why this alone isn't enough

Nix builds are atomic, and `cuda13.2-libnvshmem` alone was on pace for ~13 h at `--cores 2` in the cancelled runs — CI can never finish it to push it. The cache is being seeded once from a maintainer machine (`nix build` of the check with the `ci.runtimeDepsNixpkgs` override + `scripts/push-to-cachix.sh --build-deps`). After that, this change keeps the cache warm across nixpkgs pin bumps; cachix-action's post step runs even on the 6-hour cancellation, so partial progress is never lost.

Possible follow-up: nvshmem builds its full test/example suites (most of its 784 ninja targets); raising `--cores` could make the job self-sufficient without manual seeding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)