### PR TITLE
chore: update ComfyUI v0.32.0 → v0.33.1

### DIFF
--- a/nix/template-inputs.nix
+++ b/nix/template-inputs.nix
@@ -11,2619 +11,2663 @@ let
   # All template input files with their URLs and hashes
   inputFiles = {
     "02_qwen_Image_edit_subgraphed_input_image.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/02_qwen_Image_edit_subgraphed_input_image.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/02_qwen_Image_edit_subgraphed_input_image.png";
       hash = "sha256-59bT3r+KLjOVC6FxJv/nqb0i2hh2xAljavb3R6KsEjA=";
     };
     "03_video_wan2_2_14B_i2v_subgraphed_input_image.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/03_video_wan2_2_14B_i2v_subgraphed_input_image.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/03_video_wan2_2_14B_i2v_subgraphed_input_image.png";
       hash = "sha256-j9P3/eDmdh2A5nkNN/TfRFScegnwyMaS/8wSyQtZkFY=";
     };
     "04_hunyuan_3d_2.1_subgraphed_input_image.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/04_hunyuan_3d_2.1_subgraphed_input_image.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/04_hunyuan_3d_2.1_subgraphed_input_image.png";
       hash = "sha256-SGLOW2OPYQvQrDF0dZVSBGEZ6LWfmC3W0U1Yl6CwGfI=";
     };
     "1950_new_york.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/1950_new_york.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/1950_new_york.png";
       hash = "sha256-5UO/5aN/MZkUThHaQYAKn7EaQs3T/86CDMCroxmYVZM=";
     };
     "2_pass_pose_worship_input.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/2_pass_pose_worship_input.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/2_pass_pose_worship_input.png";
       hash = "sha256-2D2VWXfj+QUzEC4PNuqqjkdIMWk4yO2Jh2OULFHXmgA=";
     };
     "2x2_grid_image.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/2x2_grid_image.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/2x2_grid_image.png";
       hash = "sha256-/UAoFuXFv1NpepFLl8pcPCY38UAdKpwEmNWdmwtZPN0=";
     };
     "3d_character_back_view.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/3d_character_back_view.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/3d_character_back_view.png";
       hash = "sha256-sSkd69s+7Cm3C4QGoMXQo+jsKgURWZ/0701kewPGdXU=";
     };
     "3d_character_front_view.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/3d_character_front_view.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/3d_character_front_view.png";
       hash = "sha256-6eKd35/x3RG+QaVyDx0Q8nauEgpJ/Iii50b1R5QvP2Q=";
     };
     "3d_character_left_view.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/3d_character_left_view.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/3d_character_left_view.png";
       hash = "sha256-KWVsU4PsYEfVB8bZIqd/0San7X4JYI7Fz/k6cr5/dZ4=";
     };
     "3d_hunyuan3d-v2.1_input_image.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/3d_hunyuan3d-v2.1_input_image.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/3d_hunyuan3d-v2.1_input_image.png";
       hash = "sha256-tojqBCMgbT8gixzRktQbDRG/VAkgsu6gUi8y2DXaDD4=";
     };
     "3d_hunyuan3d_image_to_model_input_image.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/3d_hunyuan3d_image_to_model_input_image.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/3d_hunyuan3d_image_to_model_input_image.png";
       hash = "sha256-AA+/kxSPY4Fq6nZUAOmMv0kWqHtJKNcQb8CSrH8Jrzk=";
     };
     "3d_hunyuan3d_multiview_to_model_back_image.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/3d_hunyuan3d_multiview_to_model_back_image.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/3d_hunyuan3d_multiview_to_model_back_image.png";
       hash = "sha256-HAdO5wQRGSkuvRJiSzP4K4kAmAm+zgcPDJchT9QzIg4=";
     };
     "3d_hunyuan3d_multiview_to_model_front_image.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/3d_hunyuan3d_multiview_to_model_front_image.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/3d_hunyuan3d_multiview_to_model_front_image.png";
       hash = "sha256-6Cklgrwi8Uhf4KUdfeIIipKphVXWA8YkUPxfcPRBbtg=";
     };
     "3d_hunyuan3d_multiview_to_model_left_image.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/3d_hunyuan3d_multiview_to_model_left_image.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/3d_hunyuan3d_multiview_to_model_left_image.png";
       hash = "sha256-uf8zSzu5i/2WXtt/+FkNks13shC5rtBfcxzq1DtCjow=";
     };
     "3d_hunyuan3d_multiview_to_model_right_image.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/3d_hunyuan3d_multiview_to_model_right_image.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/3d_hunyuan3d_multiview_to_model_right_image.png";
       hash = "sha256-owB6TRcfwncBz8cLX6kl56UC9Qo8Trl7KrtEQoamPzE=";
     };
     "3d_hunyuan3d_multiview_to_model_turbo_back_view.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/3d_hunyuan3d_multiview_to_model_turbo_back_view.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/3d_hunyuan3d_multiview_to_model_turbo_back_view.png";
       hash = "sha256-O9mvgB1fwrOM4tMWx8aL6iFhicg2Og/hmq7FxTS3uzc=";
     };
     "3d_hunyuan3d_multiview_to_model_turbo_front_view.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/3d_hunyuan3d_multiview_to_model_turbo_front_view.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/3d_hunyuan3d_multiview_to_model_turbo_front_view.png";
       hash = "sha256-d4RmlAT27B6V7nQcZyE0NAekpr8PCjUryQAi6QNy57w=";
     };
     "3d_hunyuan3d_multiview_to_model_turbo_left_view.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/3d_hunyuan3d_multiview_to_model_turbo_left_view.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/3d_hunyuan3d_multiview_to_model_turbo_left_view.png";
       hash = "sha256-35xmPXOjvKNNzmYrNPU2eZNcFvA3tOkYWrWnt2H1urY=";
     };
     "3d_hunyuan3d_multiview_to_model_turbo_right_view.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/3d_hunyuan3d_multiview_to_model_turbo_right_view.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/3d_hunyuan3d_multiview_to_model_turbo_right_view.png";
       hash = "sha256-0PSEki9dwDX3jkKHdZC4ariiHfBHVjqQdPuTPBqhZQ0=";
     };
     "6-key-frames-1.jpg" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/6-key-frames-1.jpg";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/6-key-frames-1.jpg";
       hash = "sha256-E6wSB459UrZQ4oEMRjoYvCfL4OqTKZxhqxVWDzlrC+E=";
     };
     "6-key-frames-2.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/6-key-frames-2.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/6-key-frames-2.png";
       hash = "sha256-gLAlOFl9+UoZV0mTURdZyXyMh421i7HUhBEAPLuhXzk=";
     };
     "6-key-frames-3.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/6-key-frames-3.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/6-key-frames-3.png";
       hash = "sha256-GlxZBG8ObuZPnXMI0vMC/+QKna3QD05rY7M3dD393tg=";
     };
     "6-key-frames-4.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/6-key-frames-4.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/6-key-frames-4.png";
       hash = "sha256-OPHcp5StWDzyvSwPBJtCWmn9oWyPn3QVHkNJ4Qxm6Gc=";
     };
     "6-key-frames-5.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/6-key-frames-5.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/6-key-frames-5.png";
       hash = "sha256-s8hYVFsJcXJyaZ1WSmVOu3q/UG7kja787nlBcnBOITY=";
     };
     "6-key-frames-6.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/6-key-frames-6.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/6-key-frames-6.png";
       hash = "sha256-7a1lfkqn1s8nLYP1cnWLjBAoknhwpJj09EkFQcdJW3s=";
     };
     "9panel_storyboard_golden_hour_clay_court.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/9panel_storyboard_golden_hour_clay_court.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/9panel_storyboard_golden_hour_clay_court.png";
       hash = "sha256-N6oTpjRHdrE9KRirmyHM7cCEPBnp1FRNcHrT01C7YLU=";
     };
     "AIrt_MAchIne_init.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/AIrt_MAchIne_init.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/AIrt_MAchIne_init.png";
       hash = "sha256-4fk+U9wehDQpn4dri0i9pQojEX6BIO7SZi7d4jUIUDs=";
     };
     "Init.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/Init.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/Init.png";
       hash = "sha256-jHPUl+kEbdANdw4RqNb+HXZsARPudb5Y7/3gtdSl0yA=";
     };
     "Mask.mp4" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/Mask.mp4";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/Mask.mp4";
       hash = "sha256-ivKD5I1yyWZTUTGZCVdjuXRWewwIS0f5rY9Bq3gmE2c=";
     };
     "Noise_injection.mp4" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/Noise_injection.mp4";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/Noise_injection.mp4";
       hash = "sha256-pKp3AbS/tIVJTcibTiGtK1d4C1u+rrpLM4RBYVtD+Yk=";
     };
     "Urban_Fashion.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/Urban_Fashion.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/Urban_Fashion.png";
       hash = "sha256-nylkaZhQLT8HEsKztkAPq0JM/idtABPUiAmxrZXTFzc=";
     };
     "abstract_horse.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/abstract_horse.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/abstract_horse.png";
       hash = "sha256-RAZiP+ViwtNZbXtmc9YO38TqJsN1ctPJyvuZ7NgHios=";
     };
     "ad_video_demo.mp4" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/ad_video_demo.mp4";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/ad_video_demo.mp4";
       hash = "sha256-1GAFmC0HWaQl80yn886S3nzkBzoLs+tkOm4dM2uqz84=";
     };
     "alien_world.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/alien_world.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/alien_world.png";
       hash = "sha256-xomKCACY3CbFk5RglYRe2ZcSmVoCfq/Z0CqZMim9eJQ=";
     };
     "angel-warrior-demon-battle-end.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/angel-warrior-demon-battle-end.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/angel-warrior-demon-battle-end.png";
       hash = "sha256-83ysbZOkSNBjkcTuFafoI1I7YsAj0eRl4geZ4GAAIFQ=";
     };
     "angel-warrior-demon-battle-start.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/angel-warrior-demon-battle-start.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/angel-warrior-demon-battle-start.png";
       hash = "sha256-JTJhBmNL/OYiRp6Dg7dPHcaWup8B3UHRhN2TCbOhm+8=";
     };
     "angle_1.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/angle_1.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/angle_1.png";
       hash = "sha256-m+2vqn0wFRFkBeFTo/C8WA4GTCQ4yvnATfu20zAlku8=";
     };
     "angle_2.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/angle_2.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/angle_2.png";
       hash = "sha256-s59c8GM7+8GuELeZ9KxdZ7nLtpgWbigRjnLd3y1DQRY=";
     };
     "angle_3.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/angle_3.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/angle_3.png";
       hash = "sha256-0XhByjY9pciv+JdcO3TlhOJgUG5zDOK68j5cyT3Yc1o=";
     };
     "angle_4.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/angle_4.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/angle_4.png";
       hash = "sha256-0XhByjY9pciv+JdcO3TlhOJgUG5zDOK68j5cyT3Yc1o=";
     };
     "anima_depth_ref.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/anima_depth_ref.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/anima_depth_ref.png";
       hash = "sha256-Y3vdR7v/G9k7HE0JYjYFT54AHU11Ns9CKrd+KFcsP5s=";
     };
     "animated_man_framing.mp4" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/animated_man_framing.mp4";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/animated_man_framing.mp4";
       hash = "sha256-AgEPub8vqW20MIZVEZROhiNIrHbzfiaZZJYj3oZUWq8=";
     };
     "animatediff-weighted_ipadapters-input1.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/animatediff-weighted_ipadapters-input1.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/animatediff-weighted_ipadapters-input1.png";
       hash = "sha256-9z5n143sdVl4apjjWSt13esEa5QInrSJut/Uq73thrA=";
     };
     "animatediff-weighted_ipadapters-input2.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/animatediff-weighted_ipadapters-input2.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/animatediff-weighted_ipadapters-input2.png";
       hash = "sha256-Ii/IwnhFlqjsK+k5PN8MhekoI8cPFYfTv8xFf+JEfhc=";
     };
     "animatediff-weighted_ipadapters-input3.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/animatediff-weighted_ipadapters-input3.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/animatediff-weighted_ipadapters-input3.png";
       hash = "sha256-lTRRl6H1AYJSIKjxpP+GSB7lMfWROSe6GzaHORzNJEA=";
     };
     "api_bfl_flux_1_kontext_max_image_style_ref.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/api_bfl_flux_1_kontext_max_image_style_ref.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/api_bfl_flux_1_kontext_max_image_style_ref.png";
       hash = "sha256-kNZd+gAmydTfqBcN5+pAwBXTYK+F1l4wEycJqe8Z7q0=";
     };
     "api_bfl_flux_1_kontext_multiple_images_input_dog.jpg" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/api_bfl_flux_1_kontext_multiple_images_input_dog.jpg";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/api_bfl_flux_1_kontext_multiple_images_input_dog.jpg";
       hash = "sha256-B+B07v14EWIhSpo1zfsYtY2ZdFlPbHV6Ic8CQBLzqF4=";
     };
     "api_bfl_flux_1_kontext_multiple_images_input_girl.jpg" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/api_bfl_flux_1_kontext_multiple_images_input_girl.jpg";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/api_bfl_flux_1_kontext_multiple_images_input_girl.jpg";
       hash = "sha256-UIwo5IeprbE6yEohGfFTgdaoOwHIBMWAyFz6WjG0ySc=";
     };
     "api_bfl_flux_1_kontext_multiple_images_input_sofa.jpg" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/api_bfl_flux_1_kontext_multiple_images_input_sofa.jpg";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/api_bfl_flux_1_kontext_multiple_images_input_sofa.jpg";
       hash = "sha256-DI4s+SUzOuvWW99gvY+cxS5gU7DKCm9qroZc/D2Qg/0=";
     };
     "api_bfl_flux_1_kontext_pro_image_input_image.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/api_bfl_flux_1_kontext_pro_image_input_image.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/api_bfl_flux_1_kontext_pro_image_input_image.png";
       hash = "sha256-z5Z8UX0GGMOogulkwSiWdOFNqMZHDyOvw8IDwgYVS9A=";
     };
     "api_bytedance_flf2v_first_frame.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/api_bytedance_flf2v_first_frame.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/api_bytedance_flf2v_first_frame.png";
       hash = "sha256-YbXKRG50HeSTyQ4cXCmbfE2h2sWx+tFDrQdXwJRzS28=";
     };
     "api_bytedance_flf2v_last_frame.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/api_bytedance_flf2v_last_frame.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/api_bytedance_flf2v_last_frame.png";
       hash = "sha256-rpJum+py5AUBjvALj+NIRHBHsQvhj6alN5RWtMdtBW4=";
     };
     "api_bytedance_image_to_video_input_image.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/api_bytedance_image_to_video_input_image.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/api_bytedance_image_to_video_input_image.png";
       hash = "sha256-z5TrGQ2Rr0HgbXTioEIPgUuDbz50+Uh9k8bsVPEQGpU=";
     };
     "api_elevenlabs_speech_to_speech.mp3" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/api_elevenlabs_speech_to_speech.mp3";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/api_elevenlabs_speech_to_speech.mp3";
       hash = "sha256-Wp8YhlzMJneChUpgU2WyHyiNo7721T0TME6cQoqicUI=";
     };
     "api_flux2_input_image_1.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/api_flux2_input_image_1.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/api_flux2_input_image_1.png";
       hash = "sha256-cUq+sJuG7kjgvjKpSoGBrStW/7+E4+aFmp8O7K4AS5A=";
     };
     "api_flux2_input_image_2.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/api_flux2_input_image_2.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/api_flux2_input_image_2.png";
       hash = "sha256-3mjFB2xVLRuCYXToUr1qFNYBNAJeqtlbxGC9kk+7suI=";
     };
     "api_flux2_input_image_3.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/api_flux2_input_image_3.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/api_flux2_input_image_3.png";
       hash = "sha256-ncdruDqm2vppQgrFcjuqY6s7Z4UINdnxnWpJw+IDcZo=";
     };
     "api_flux2_input_image_4.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/api_flux2_input_image_4.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/api_flux2_input_image_4.png";
       hash = "sha256-O4UiI8vJpCFd8iKa+Fj+cn6HQgr4JlCNg3rFZuhj8ww=";
     };
     "api_from_photo_2_miniature_input_image.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/api_from_photo_2_miniature_input_image.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/api_from_photo_2_miniature_input_image.png";
       hash = "sha256-NBU3XyOYMa6/p1LZmerKrlKmMctLg/8FbGuW+opECew=";
     };
     "api_hailuo_minimax_i2v_input_image.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/api_hailuo_minimax_i2v_input_image.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/api_hailuo_minimax_i2v_input_image.png";
       hash = "sha256-Wl2IXJ83VKoSb7+nmgqFDh3qQOIiczHlIkse6KYXZ94=";
     };
     "api_hailuo_minimax_video_first_frame.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/api_hailuo_minimax_video_first_frame.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/api_hailuo_minimax_video_first_frame.png";
       hash = "sha256-Ccwv+Qsoh2c3Mrl+zQkMMxCWf+v1FIA8IgI2lkbenG4=";
     };
     "api_kling_effects_input_image.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/api_kling_effects_input_image.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/api_kling_effects_input_image.png";
       hash = "sha256-CALDdXih977L9vxxFwslOAo7D1t8OWgmQVEtMZvzmdY=";
     };
     "api_kling_flf_first_frame.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/api_kling_flf_first_frame.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/api_kling_flf_first_frame.png";
       hash = "sha256-sed5uXIjgFC+xrPmXWQ1xWdywejn/ywaFMUHLuD2Qno=";
     };
     "api_kling_flf_last_frame.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/api_kling_flf_last_frame.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/api_kling_flf_last_frame.png";
       hash = "sha256-3PAZCNwJeHbbnVZKJr5p0NyNBommpQRgeoalIPK/VNo=";
     };
     "api_kling_i2v_input_image.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/api_kling_i2v_input_image.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/api_kling_i2v_input_image.png";
       hash = "sha256-5Ns97FtZeuzel8+v26QYIwukcWMvENSN6TecECPypl4=";
     };
     "api_kling_omni_edit_video_input_image.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/api_kling_omni_edit_video_input_image.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/api_kling_omni_edit_video_input_image.png";
       hash = "sha256-RBSQqdKEJ23xgdJEn9xvp2596DFONvO4uZedRX6IkZo=";
     };
     "api_kling_omni_edit_video_input_video.mp4" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/api_kling_omni_edit_video_input_video.mp4";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/api_kling_omni_edit_video_input_video.mp4";
       hash = "sha256-QcqDD59FRsa2Lr+6R6uMEG9pvx0uT+qvRb/2HelTeik=";
     };
     "api_ltxv_image_to_video_input_image.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/api_ltxv_image_to_video_input_image.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/api_ltxv_image_to_video_input_image.png";
       hash = "sha256-RMy/4N82ERXcwheuve9jdWYS2T7kOij4dIbdMSCtu0o=";
     };
     "api_luma_i2v_input_image.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/api_luma_i2v_input_image.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/api_luma_i2v_input_image.png";
       hash = "sha256-fTvwvjDSeohWQeBAt4Y3b7K4/Ufs/pTGD2lbh3BFlZg=";
     };
     "api_luma_photon_i2i_input_image.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/api_luma_photon_i2i_input_image.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/api_luma_photon_i2i_input_image.png";
       hash = "sha256-QVoS5yjUs594+vt6gX+lpuGHfeedryBhsoX8d9rUa/o=";
     };
     "api_luma_photon_i2i_ref_image_1.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/api_luma_photon_i2i_ref_image_1.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/api_luma_photon_i2i_ref_image_1.png";
       hash = "sha256-0pCfGHQUjUYbLs2ZLtFyNIE5dHwQ2EOBqZQNa/6ECoU=";
     };
     "api_luma_photon_i2i_ref_image_2.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/api_luma_photon_i2i_ref_image_2.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/api_luma_photon_i2i_ref_image_2.png";
       hash = "sha256-3nrEGDdZ3eKAlhlLKEYLsOj+JHTMFk8JZT2XL9oOWRU=";
     };
     "api_moonvalley_image_to_video_input_image.jpg" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/api_moonvalley_image_to_video_input_image.jpg";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/api_moonvalley_image_to_video_input_image.jpg";
       hash = "sha256-g+Tytx53vqiSK4cSCv7r7fs5aW/2ctRKFZZdN1utP58=";
     };
     "api_moonvalley_video_to_video_motion_transfer_input_video.mp4" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/api_moonvalley_video_to_video_motion_transfer_input_video.mp4";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/api_moonvalley_video_to_video_motion_transfer_input_video.mp4";
       hash = "sha256-7vAoYTJCiCXzvsXH4hbcA9IkiCLydOQDUowIH5uv6zc=";
     };
     "api_moonvalley_video_to_video_pose_control_input_video.mp4" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/api_moonvalley_video_to_video_pose_control_input_video.mp4";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/api_moonvalley_video_to_video_pose_control_input_video.mp4";
       hash = "sha256-HaHEpTDxmoNf6NsC56sxLqCMVfLQHXDBto6SWc6LMEw=";
     };
     "api_nano_banana_pro_input_image_1.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/api_nano_banana_pro_input_image_1.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/api_nano_banana_pro_input_image_1.png";
       hash = "sha256-xL+Ms7CmJWAeUJyeVkV2dPE3icOLAW8laOprFb7myX0=";
     };
     "api_nano_banana_pro_input_image_2.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/api_nano_banana_pro_input_image_2.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/api_nano_banana_pro_input_image_2.png";
       hash = "sha256-YV8dilDV7lX7ViyuEGof8Mdca+R5lLpHB9X/Ramul+Q=";
     };
     "api_openai_dall_e_2_inpaint_input_image.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/api_openai_dall_e_2_inpaint_input_image.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/api_openai_dall_e_2_inpaint_input_image.png";
       hash = "sha256-4r3Y2cqxOn35O8SQwyaT68I3GCPKWOjKi1YwGZyQo/I=";
     };
     "api_openai_image_1_hat.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/api_openai_image_1_hat.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/api_openai_image_1_hat.png";
       hash = "sha256-NWTThErUmUca/q40mrF9vG00aAUt7Y3sXF1l2EYVUKA=";
     };
     "api_openai_image_1_input_image.jpg" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/api_openai_image_1_input_image.jpg";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/api_openai_image_1_input_image.jpg";
       hash = "sha256-8MFj8yq5NjbG5iv5FLJNyX1mhBr4hh8JEbq289ZyYS4=";
     };
     "api_openai_image_1_input_image_mask.jpg" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/api_openai_image_1_input_image_mask.jpg";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/api_openai_image_1_input_image_mask.jpg";
       hash = "sha256-xzNopgjOS6rpgtzmAOEXOVdpbzTMG9bqAZhSwEHuIlc=";
     };
     "api_openai_sora_video_input_image.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/api_openai_sora_video_input_image.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/api_openai_sora_video_input_image.png";
       hash = "sha256-etVtOOYz9Z+1VJhzNQYh8O8cKmWE0bpx8EVENZJBzUY=";
     };
     "api_pika_i2v_input_image.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/api_pika_i2v_input_image.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/api_pika_i2v_input_image.png";
       hash = "sha256-ODFaeU3nO1Yt73Z7RSeVSI7HrvQnSkuJooCutPDEkIQ=";
     };
     "api_pika_scene_ref_image_1.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/api_pika_scene_ref_image_1.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/api_pika_scene_ref_image_1.png";
       hash = "sha256-aalWv2G+aS5yhCxeuU8NwqfnR0fPQEY0qTnTBnbKKAo=";
     };
     "api_pika_scene_ref_image_2.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/api_pika_scene_ref_image_2.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/api_pika_scene_ref_image_2.png";
       hash = "sha256-rheGEjYnr/XwP4gBUfbHL173zny6j3QuZn1mT07vEio=";
     };
     "api_pixverse_template_i2v_input_image.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/api_pixverse_template_i2v_input_image.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/api_pixverse_template_i2v_input_image.png";
       hash = "sha256-SvQUZtUi7cZaTmD/THQa/ujGc/XIjtY88R6MQvtaYLw=";
     };
     "api_rodin_gen2_input_image.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/api_rodin_gen2_input_image.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/api_rodin_gen2_input_image.png";
       hash = "sha256-vGFcKPZwOvOWA0Dy2i/BQl8WM1awzophp/CoddPjkKc=";
     };
     "api_rodin_image_to_model_input_image.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/api_rodin_image_to_model_input_image.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/api_rodin_image_to_model_input_image.png";
       hash = "sha256-/Lmlt8XHCBDgE40OtPBzD2nDbsr/yo7K22B+45ceU3s=";
     };
     "api_rodin_multiview_to_model_back.jpg" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/api_rodin_multiview_to_model_back.jpg";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/api_rodin_multiview_to_model_back.jpg";
       hash = "sha256-wqQMr9xUo6IssmvnGG5Y6C+tnZec5wjLFJvQSPDWQkE=";
     };
     "api_rodin_multiview_to_model_front.jpg" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/api_rodin_multiview_to_model_front.jpg";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/api_rodin_multiview_to_model_front.jpg";
       hash = "sha256-SFIMrl7IPA54je8dE/JfRRryt26/B+iCbWkwqxI4ORw=";
     };
     "api_rodin_multiview_to_model_left.jpg" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/api_rodin_multiview_to_model_left.jpg";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/api_rodin_multiview_to_model_left.jpg";
       hash = "sha256-hycgIV7pqk2nuvqF0947VyR0gD4J2zX+GyiEz1scCio=";
     };
     "api_runway_first_last_frame_first_frame.jpg" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/api_runway_first_last_frame_first_frame.jpg";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/api_runway_first_last_frame_first_frame.jpg";
       hash = "sha256-oCnSvvoQS9FL1GJXw6PPcjvC2BLeQTHhEb6ZOjGoJ7g=";
     };
     "api_runway_first_last_frame_last_frame.jpg" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/api_runway_first_last_frame_last_frame.jpg";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/api_runway_first_last_frame_last_frame.jpg";
       hash = "sha256-EF7JNm833S9HWOPPlJ+zi+8o63vRbOOMf9VdRb82iaw=";
     };
     "api_runway_gen3a_turbo_image_to_video_input_image.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/api_runway_gen3a_turbo_image_to_video_input_image.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/api_runway_gen3a_turbo_image_to_video_input_image.png";
       hash = "sha256-tJTitqMYwIbPGwWFjYgLi4RIwxU2Cyd9Dnc7JvuL4Cw=";
     };
     "api_runway_gen4_turo_image_to_video_input_image.jpg" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/api_runway_gen4_turo_image_to_video_input_image.jpg";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/api_runway_gen4_turo_image_to_video_input_image.jpg";
       hash = "sha256-RkouDCAmS+8x2VEHXr2FpJIEDfsiqHFB9GyzrDdakxE=";
     };
     "api_runway_reference_to_image_input_image.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/api_runway_reference_to_image_input_image.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/api_runway_reference_to_image_input_image.png";
       hash = "sha256-GNcouMimGoYv4MYLpyAH1eeuXRUYJjEMteNhU1UCn48=";
     };
     "api_stability_ai_audio_inpaint_input_audio.wav" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/api_stability_ai_audio_inpaint_input_audio.wav";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/api_stability_ai_audio_inpaint_input_audio.wav";
       hash = "sha256-CASfQv80I5A+63+dRq43PIgTZ1bu3sjFvfZXBFgdQPE=";
     };
     "api_stability_ai_audio_to_audio_input_audio.mp3" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/api_stability_ai_audio_to_audio_input_audio.mp3";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/api_stability_ai_audio_to_audio_input_audio.mp3";
       hash = "sha256-Xa5F7M/MckniFg5EsUvCjCJoyibmQj9n3P3Uhtv2XQA=";
     };
     "api_stability_ai_i2i_input_image.jpg" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/api_stability_ai_i2i_input_image.jpg";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/api_stability_ai_i2i_input_image.jpg";
       hash = "sha256-DeXsVuFAHdXdu2c+j37NrTlGrgFY94G3orWMzCUVsUw=";
     };
     "api_stability_ai_sd3.5_i2i_input_image.jpg" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/api_stability_ai_sd3.5_i2i_input_image.jpg";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/api_stability_ai_sd3.5_i2i_input_image.jpg";
       hash = "sha256-VkA5QYKb4HE5HCcEVKq8l2N0JfeNPhgIFl3tpPrcLVQ=";
     };
     "api_topaz_image_enhance_input_image.webp" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/api_topaz_image_enhance_input_image.webp";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/api_topaz_image_enhance_input_image.webp";
       hash = "sha256-acTP47zK+mzpKoyyx6rJYhHnyUnOhvoj7oX6yAu7v3k=";
     };
     "api_topaz_video_enhance_input_video.mp4" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/api_topaz_video_enhance_input_video.mp4";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/api_topaz_video_enhance_input_video.mp4";
       hash = "sha256-BDFw2mgCwJx5wF5DrDe+42F505UNZFdDfeGMZRlyAh4=";
     };
     "api_tripo_image_to_model_input_image.jpg" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/api_tripo_image_to_model_input_image.jpg";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/api_tripo_image_to_model_input_image.jpg";
       hash = "sha256-gxzU+8pr1D0EtdnN97rSV/2UThUdt4QeNP/fBFEuc1I=";
     };
     "api_tripo_multiview_to_model_back_image.jpg" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/api_tripo_multiview_to_model_back_image.jpg";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/api_tripo_multiview_to_model_back_image.jpg";
       hash = "sha256-wv6TQLYSeGL4pjikvdeODAUcRot1wOt17c+4RgFhqDo=";
     };
     "api_tripo_multiview_to_model_front_image.jpg" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/api_tripo_multiview_to_model_front_image.jpg";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/api_tripo_multiview_to_model_front_image.jpg";
       hash = "sha256-mM43dcyybQQ932wc/uqoCmt1tLQxz0k8BiyIzX9EpK8=";
     };
     "api_veo2_i2v_input_image.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/api_veo2_i2v_input_image.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/api_veo2_i2v_input_image.png";
       hash = "sha256-Menr+nqMIwiKhy+9InVSQkdy6KFCfJV/Bkev+pQ7Id0=";
     };
     "api_veo3_input_image.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/api_veo3_input_image.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/api_veo3_input_image.png";
       hash = "sha256-pCUoMBkxy5noLu81ftizeaWL2kKALJppJopxXWgI3bY=";
     };
     "api_vidu_image_to_video_input_image.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/api_vidu_image_to_video_input_image.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/api_vidu_image_to_video_input_image.png";
       hash = "sha256-CtM1LgYT5D4/E0ZHQ3QWhwcCMXXi9Og4iHFsFWPnx4k=";
     };
     "api_vidu_q2_r2v_red_haired_girl.jpg" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/api_vidu_q2_r2v_red_haired_girl.jpg";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/api_vidu_q2_r2v_red_haired_girl.jpg";
       hash = "sha256-Ld949sGP6V+SHdx8z4z2/9MxbSf+ji0vK9bfxHcMy9w=";
     };
     "api_vidu_reference_to_video_reference_image_1.jpg" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/api_vidu_reference_to_video_reference_image_1.jpg";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/api_vidu_reference_to_video_reference_image_1.jpg";
       hash = "sha256-d16kaTDCHVzL6moAbVGd+OZYyyKHv6pRt+AgAE4YKwQ=";
     };
     "api_vidu_reference_to_video_reference_image_2.jpg" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/api_vidu_reference_to_video_reference_image_2.jpg";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/api_vidu_reference_to_video_reference_image_2.jpg";
       hash = "sha256-bHx2mDe3etuFoKZox81S1HJZ5cuvf0AzRodShJnvRwQ=";
     };
     "api_vidu_reference_to_video_reference_image_3.jpg" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/api_vidu_reference_to_video_reference_image_3.jpg";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/api_vidu_reference_to_video_reference_image_3.jpg";
       hash = "sha256-e5QLQ4kt0FieWwAmtx+zIcRgx+oRfMx2lO4mt0SBuDI=";
     };
     "api_vidu_start_end_to_video_last_frame.jpg" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/api_vidu_start_end_to_video_last_frame.jpg";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/api_vidu_start_end_to_video_last_frame.jpg";
       hash = "sha256-tITHRN2XKBxK4vAaSwm9zhRSopo78vZxHaWdLNzO8ks=";
     };
     "api_vidu_start_end_to_video_start_frame.jpg" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/api_vidu_start_end_to_video_start_frame.jpg";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/api_vidu_start_end_to_video_start_frame.jpg";
       hash = "sha256-2TiUfe+QZeH9JegKxsmn1CsrQB3L5e64U+yW9VtCka8=";
     };
     "api_wan_image_to_video_input_image.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/api_wan_image_to_video_input_image.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/api_wan_image_to_video_input_image.png";
       hash = "sha256-JrksHkqmdNmuFvtcmjz6xDzsyQpNkckrjCauC1ZpBx0=";
     };
     "armored_warrior.mp4" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/armored_warrior.mp4";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/armored_warrior.mp4";
       hash = "sha256-FtXxfb9fMa66d+oFojVrU0ET79scTddyppA/181egwQ=";
     };
     "art_gallery_dancer.mp4" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/art_gallery_dancer.mp4";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/art_gallery_dancer.mp4";
       hash = "sha256-u9vDbRbNhPmhZYckMQYhxojN3Fddz0VEg3/lEfRyb3Q=";
     };
     "asian_model_in_white_clothes.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/asian_model_in_white_clothes.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/asian_model_in_white_clothes.png";
       hash = "sha256-kqnp+iTDmgmF24ho6DlOjA9NV1U9sHMBjAIYl9737Z0=";
     };
     "asian_model_white_top.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/asian_model_white_top.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/asian_model_white_top.png";
       hash = "sha256-kqnp+iTDmgmF24ho6DlOjA9NV1U9sHMBjAIYl9737Z0=";
     };
     "audio_ace_step_1_m2m_editing_input_audio.mp3" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/audio_ace_step_1_m2m_editing_input_audio.mp3";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/audio_ace_step_1_m2m_editing_input_audio.mp3";
       hash = "sha256-VY9O3l8XxVeWAFJhr+fJy8j9VmUqWoE4zAfXm0HEOa0=";
     };
     "audio_speaker1_woman.mp3" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/audio_speaker1_woman.mp3";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/audio_speaker1_woman.mp3";
       hash = "sha256-0AhJSXbjSwUQjxgZQqbUNj4r8RduurwQ7LadLmEkWvs=";
     };
     "audio_speaker2_man.mp3" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/audio_speaker2_man.mp3";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/audio_speaker2_man.mp3";
       hash = "sha256-YyrstFOppY03+fnnDQf2dIq2BK9ZpWS4TrdgMUQNNUU=";
     };
     "baby_otter.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/baby_otter.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/baby_otter.png";
       hash = "sha256-Gu/PIxjXXybynlqiEBuMfhpc0ByFkO3qTi+id5GhyKo=";
     };
     "billboard.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/billboard.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/billboard.png";
       hash = "sha256-Q4OjXIRPXei1Ny5o57/Vacgy63srihBDtzg5Vb7DtzU=";
     };
     "black_coat_model.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/black_coat_model.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/black_coat_model.png";
       hash = "sha256-q4P8AS08lpOUte9f+3sInyd5i6XkWUTa2/vS7p9PNI0=";
     };
     "blue_dancer.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/blue_dancer.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/blue_dancer.png";
       hash = "sha256-mrvOFoLWijzqZBZH2s75dimSNLY+EC4roF8BQngL8YA=";
     };
     "blue_poppies_field.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/blue_poppies_field.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/blue_poppies_field.png";
       hash = "sha256-qbk5RRjyx/wrdre+jsyAWWrPQ+7hil4bYx5rhNSfICw=";
     };
     "blue_shirt_rabbit.jpg" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/blue_shirt_rabbit.jpg";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/blue_shirt_rabbit.jpg";
       hash = "sha256-hZg5zpKj0UTtHv9wZGzyp/tQtRMvI5BPcIlb00kkqdQ=";
     };
     "blue_tone_woman.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/blue_tone_woman.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/blue_tone_woman.png";
       hash = "sha256-KfjST3Ks9fCEuvRaI8fUw8LRe64QALjAJVQlDeqmEu8=";
     };
     "blurred_vintage_car.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/blurred_vintage_car.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/blurred_vintage_car.png";
       hash = "sha256-2oiB31sU+BICPjBMdwODUn5IWKOo3wFqMXVmpHdjsVk=";
     };
     "blurry_city_horses.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/blurry_city_horses.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/blurry_city_horses.png";
       hash = "sha256-jZPitbRuEhjyfwurVQJsiNn0c7ojdKTz69Qa+xYkn3I=";
     };
     "bohemian_style.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/bohemian_style.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/bohemian_style.png";
       hash = "sha256-4K6uB8PCcCB6aEDV97MXUsv7PNwiXw1P3tZw0V3wp20=";
     };
     "bold_outfit_woman.jpeg" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/bold_outfit_woman.jpeg";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/bold_outfit_woman.jpeg";
       hash = "sha256-HT3cIt+vLhL8M2CmMdSqIa98QyU8sDfdKN211mxD+fU=";
     };
     "boxing.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/boxing.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/boxing.png";
       hash = "sha256-PBoa28r2eMEHj0U28pd9VT31xK0iS8KKXs556zWKBnM=";
     };
     "boxing_man.mp4" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/boxing_man.mp4";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/boxing_man.mp4";
       hash = "sha256-WpNI2slNhVQ7RY9ivLzhH52EdOkyIae631WnoVRYk+M=";
     };
     "brown_moisturizer_bottle.jpg" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/brown_moisturizer_bottle.jpg";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/brown_moisturizer_bottle.jpg";
       hash = "sha256-0r/0gGCoiBqbmFY4uug46xhbw8xeZ2+GqZ5AKoc9Xr8=";
     };
     "bull_robot.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/bull_robot.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/bull_robot.png";
       hash = "sha256-g53wjZwlxRBW08YzNtB/TWB+QSezuS8psIoL5cpHpXo=";
     };
     "butterfly_girl.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/butterfly_girl.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/butterfly_girl.png";
       hash = "sha256-4VEYt8Ul6JSd1MWFS0jKztzNLzPp66G470QlHymdPWU=";
     };
     "cactus_man.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/cactus_man.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/cactus_man.png";
       hash = "sha256-9tevEHEDH8GZHRuRZfdXWMQavptWnnQo9WLfsD8/naw=";
     };
     "calm_amid_ruin.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/calm_amid_ruin.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/calm_amid_ruin.png";
       hash = "sha256-cZrw85lIHj2zho7WVpy3BFw99BdHc1hzYZJXMbuEdTw=";
     };
     "car_interior_white.jpeg" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/car_interior_white.jpeg";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/car_interior_white.jpeg";
       hash = "sha256-i2rGGeWYF6zJ2n8iRhBTIvbYGn0KHpcXiV4pczdNhVU=";
     };
     "car_ref.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/car_ref.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/car_ref.png";
       hash = "sha256-6Iq13KdvZbjy/PLkY6hVS7Eeb7NYF7wYv1BODe361WE=";
     };
     "cartier-glasses-1.jpg" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/cartier-glasses-1.jpg";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/cartier-glasses-1.jpg";
       hash = "sha256-iMHGJy7ZV7UTm7wM3BTu9EcHpmmFy3pb5SKDTA84hss=";
     };
     "castle_back_view.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/castle_back_view.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/castle_back_view.png";
       hash = "sha256-8tJSKb/FR7PCo2E/Lwu/Sl2PeBGdVzBbM/Mz8WuazMs=";
     };
     "castle_front_view.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/castle_front_view.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/castle_front_view.png";
       hash = "sha256-xpeTI6sFzHJBo//Br69cZtGa1uFrxAZY43kpTIY86CM=";
     };
     "castle_side_view.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/castle_side_view.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/castle_side_view.png";
       hash = "sha256-/2UN/DTYass6qimicn1IdXt9m5wl/TRiPEQUTc7N7vc=";
     };
     "casual_male_portrait.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/casual_male_portrait.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/casual_male_portrait.png";
       hash = "sha256-91De1Pp9NZUQuG0pc8MwkSOMAfCJ8tZ/YZg4sQUaAtA=";
     };
     "cave_ocean_living_room.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/cave_ocean_living_room.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/cave_ocean_living_room.png";
       hash = "sha256-YgJQFuDzRqdAIwYTId/eUAXc5LfFw7I1O3+nRivS0BA=";
     };
     "character-1.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/character-1.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/character-1.png";
       hash = "sha256-tibzr35+Jbq4hBdWXaUkqolpsNlQ/3eAvAoR/SaMxrA=";
     };
     "character_in_red_jacket.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/character_in_red_jacket.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/character_in_red_jacket.png";
       hash = "sha256-Fyhe0t5UpYosSCpX59mWGx+PorXQmGz4aFjW5bSn+cc=";
     };
     "character_input.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/character_input.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/character_input.png";
       hash = "sha256-2J8OxMo3fuHICQOuYX+sMR/6ITjA7hIL4jBArxLCDN4=";
     };
     "chasing_the_light.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/chasing_the_light.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/chasing_the_light.png";
       hash = "sha256-ZsUfDOf8/a5pRLOGb3KgyyH5+SGwXCnFzuoCw4bLar8=";
     };
     "chatterbox_input_gettysburg.wav" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/chatterbox_input_gettysburg.wav";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/chatterbox_input_gettysburg.wav";
       hash = "sha256-2o9PO0PvcG2oFpeZ/XOi0LCnTmHPE9mEZkoPswvtN0c=";
     };
     "chatterbox_input_target_voice.mp3" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/chatterbox_input_target_voice.mp3";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/chatterbox_input_target_voice.mp3";
       hash = "sha256-vSeMxqKwZUtV6srFdDuoboQ187PZiQe0CTOrpfbFG6c=";
     };
     "city_street_young_man.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/city_street_young_man.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/city_street_young_man.png";
       hash = "sha256-OqLTku0v35mG6ZE5y1kF/2Y0zU+fR82kJQWsdPWakQk=";
     };
     "clay_toy_shop_old_man.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/clay_toy_shop_old_man.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/clay_toy_shop_old_man.png";
       hash = "sha256-g8XyC2CVeIaRbeIcsVLqgkURw4R3ycno6doyGC9w9js=";
     };
     "close_up_girl_skin.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/close_up_girl_skin.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/close_up_girl_skin.png";
       hash = "sha256-CtvuOSWJAKBG7W2NPrX+RHB6yat3dUPAuw5dg1lXAJw=";
     };
     "close_up_portrait.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/close_up_portrait.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/close_up_portrait.png";
       hash = "sha256-wtF5B0jG72AsTs+WuBl4YP0FEQq/fSXQEfvrBkqL74o=";
     };
     "clothing.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/clothing.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/clothing.png";
       hash = "sha256-h/1BqdNdDbNquDyXH4mRed1eU6liCG02mfGj297d0Sw=";
     };
     "coastal_smiling_woman.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/coastal_smiling_woman.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/coastal_smiling_woman.png";
       hash = "sha256-14uy/od1MZOOWWAmyzxXf/evcYjLkR6ixvScHa9i0XQ=";
     };
+    "color_spin_flower.mp4" = {
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/color_spin_flower.mp4";
+      hash = "sha256-dlHZhBxHB3oRq92uhsz/TteT5WR0ObVFUYnAttWkRrM=";
+    };
     "comfy_billboard.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/comfy_billboard.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/comfy_billboard.png";
       hash = "sha256-D1+N++9od6L8MZNOPbKms1HEA77Hevo9o5Pc0ip30Ao=";
     };
     "comfy_cat.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/comfy_cat.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/comfy_cat.png";
       hash = "sha256-G6gKbL9n4+cXxgr7EGrwrvcEwzIC8+RJF1A2aVsZGbQ=";
     };
     "comfy_cloud_bottle.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/comfy_cloud_bottle.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/comfy_cloud_bottle.png";
       hash = "sha256-xW/746mZxVEYirZQ15NiAthjzYWAdN6RPFt617VoSaI=";
     };
     "comfy_cloud_water_can.jpg" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/comfy_cloud_water_can.jpg";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/comfy_cloud_water_can.jpg";
       hash = "sha256-Ja2etAUFP25K/czxV9BQwWz1KjXr2Soosc/JVIIehjs=";
     };
     "comfy_gpu.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/comfy_gpu.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/comfy_gpu.png";
       hash = "sha256-rP2wI2XdRUCMZcS/r/wud7mdZR8KKB+CtIqhRw6g9Bc=";
     };
     "comfy_gpu_angled.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/comfy_gpu_angled.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/comfy_gpu_angled.png";
       hash = "sha256-P6rgnbl/XLTahNs6gtv9JN3V8QbLJt7Dwkf0Y1VDxiA=";
     };
     "comfy_gpu_close_up.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/comfy_gpu_close_up.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/comfy_gpu_close_up.png";
       hash = "sha256-t3a8ZMW1uOW8BmAxzsmOJjU7CmQioeZWgnrVaLncDL0=";
     };
     "comfy_gpu_flat.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/comfy_gpu_flat.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/comfy_gpu_flat.png";
       hash = "sha256-XsB11GMRRGaItBFvI+YNvSM2uYBlgFqj7Nv+nqmKCMg=";
     };
     "comfy_hat.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/comfy_hat.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/comfy_hat.png";
       hash = "sha256-JX0Z6x1K1+kiX+Mdj2WmKO2uYOobeEbqpPA441QyVsc=";
     };
     "comfy_logo_b.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/comfy_logo_b.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/comfy_logo_b.png";
       hash = "sha256-RGQx12jKKENhxZYJ7e1qsKHzfRVrmATVeGWA1fRDD6E=";
     };
     "comfy_logo_blue.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/comfy_logo_blue.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/comfy_logo_blue.png";
       hash = "sha256-OStPixbTqhl3gfkVl2gZBcEyDjd7DYGvUwyHZAsES/Y=";
     };
     "comfy_logo_c.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/comfy_logo_c.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/comfy_logo_c.png";
       hash = "sha256-J0rO0sotqTs50beA052IxaPhTlTD2rgZAnfwnmq+8c0=";
     };
     "comfy_poster.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/comfy_poster.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/comfy_poster.png";
       hash = "sha256-BaOvlUXmY8wMvJFx3q+UnmhTXVH+BygOLItC5Nl3XOY=";
     };
     "comfy_shampoo.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/comfy_shampoo.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/comfy_shampoo.png";
       hash = "sha256-PK2yNZFdVLktD9rrLAUH5eBbq6CCfgqkXDGNjR+EmPY=";
     };
     "comfy_sofa.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/comfy_sofa.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/comfy_sofa.png";
       hash = "sha256-XtGj0LS1D6tjTLj4pD6kYXK+KlsDJA2i0eV+i+aJz/A=";
     };
     "comfyorg_logo.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/comfyorg_logo.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/comfyorg_logo.png";
       hash = "sha256-9l4Tn0PtOehfzldBoBQ9xQvHoSODmQM3P+Ucljn6QR0=";
     };
     "comfyui_logo.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/comfyui_logo.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/comfyui_logo.png";
       hash = "sha256-vCgOZHgXOc8C65tfKRzuF20x4dNVWOHhNQGqMnp05YE=";
     };
     "comic_toy_store_strips.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/comic_toy_store_strips.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/comic_toy_store_strips.png";
       hash = "sha256-tUL3sFexCZiy5+APEszSVhZes0U39ZVfGhFSkATrlT4=";
     };
     "contact_sheet_app_input_1.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/contact_sheet_app_input_1.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/contact_sheet_app_input_1.png";
       hash = "sha256-a6RWJF6EDBhwDwcn6MZpj8Mavvo6lKvj8k3Tiie52gc=";
     };
     "contact_sheet_app_input_2.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/contact_sheet_app_input_2.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/contact_sheet_app_input_2.png";
       hash = "sha256-KIbJrsKyLqaCy5Jx8lbYfqUfV3jzrsxS23wFV6zJbWM=";
     };
     "contact_sheet_app_input_3.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/contact_sheet_app_input_3.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/contact_sheet_app_input_3.png";
       hash = "sha256-/Jpt3UfIqHH2dJMC1gEGp5weaEz14bfjf/Pd0CM1my4=";
     };
     "contact_sheet_app_input_4.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/contact_sheet_app_input_4.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/contact_sheet_app_input_4.png";
       hash = "sha256-JwGq3nFLM6lgXcxEcPvDdf+MQ3N/iOl7a27x2QZdIpM=";
     };
     "contact_sheet_app_input_5.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/contact_sheet_app_input_5.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/contact_sheet_app_input_5.png";
       hash = "sha256-lnGPTfBz+laWbRgrVZbVi38z0PCTkJL4vCLxof0bl0A=";
     };
     "contact_sheet_app_input_6.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/contact_sheet_app_input_6.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/contact_sheet_app_input_6.png";
       hash = "sha256-xMOFYg0NC95TE5F3U6vXiWRbcD0n3kp8jGqSyCB/Dgo=";
     };
     "contact_sheet_app_input_7.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/contact_sheet_app_input_7.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/contact_sheet_app_input_7.png";
       hash = "sha256-6Z0OuS1k4udi4jjRo1QlHCA2+R7nsSBW+C/DNKkO7ho=";
     };
     "controlnet_example_input_image.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/controlnet_example_input_image.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/controlnet_example_input_image.png";
       hash = "sha256-qxT2K8sdwcQeQ5dq7E9F3z2QldoxLjENARRUiGbNwL8=";
     };
+    "cosmoscape.png" = {
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/cosmoscape.png";
+      hash = "sha256-/pFyNvHq4XlK/USnuS7x4p0donlvbZh343N//57JsNo=";
+    };
     "cozy_bear.jpg" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/cozy_bear.jpg";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/cozy_bear.jpg";
       hash = "sha256-K7OvRWDdF8JobLqHt9VZS4dhd3wAxOBEKDbJ16O5EeI=";
     };
     "crossfade_clip_1.mp4" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/crossfade_clip_1.mp4";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/crossfade_clip_1.mp4";
       hash = "sha256-NPm2DohS4HqiILkt2rbBIK+T5pBpyeOQCNtKDPFgFWk=";
     };
     "crossfade_clip_2.mp4" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/crossfade_clip_2.mp4";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/crossfade_clip_2.mp4";
       hash = "sha256-p5WCJbdusm/8GG+OHHsdsAnofsKvRrEzau97gKU8OHM=";
     };
     "crystal_flower.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/crystal_flower.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/crystal_flower.png";
       hash = "sha256-7DNzVKjWG81hT9YzkeIVZBdO0/9waGRooJ4qbMgxb3A=";
     };
     "cube_robot.jpg" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/cube_robot.jpg";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/cube_robot.jpg";
       hash = "sha256-RXJuM6YKV2WQoLhAcAR+yBaQy6S6LatpizZXpd0EPUo=";
     };
     "cyber-katana.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/cyber-katana.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/cyber-katana.png";
       hash = "sha256-apLIWPjTlSz9f4KlVShicLezqU2Jx7lA5VbR/pb5jtQ=";
     };
     "cyber_cat.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/cyber_cat.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/cyber_cat.png";
       hash = "sha256-G6Df1vAkdgzgLH0mAKHC9hdt5a60i+ZeLexE/OeLfgY=";
     };
     "cyber_fight.mp4" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/cyber_fight.mp4";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/cyber_fight.mp4";
       hash = "sha256-KwsYfTYslfmMJfB3zPFK8IB1HjFOKc1C8KHjL//hf10=";
     };
     "cyber_genesis.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/cyber_genesis.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/cyber_genesis.png";
       hash = "sha256-rSOwIGFTlJ0FxNZx7iLPOAASmdl9yLc9PrqW6XexQX8=";
     };
     "cybernetic_robot.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/cybernetic_robot.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/cybernetic_robot.png";
       hash = "sha256-nZ5bwXc3KmmLJWd01pQLiWC7TkGU7jSkGpYhR63/+Ig=";
     };
     "cyberpunk_robot.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/cyberpunk_robot.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/cyberpunk_robot.png";
       hash = "sha256-8hFk4RdYBtRY45oeBs2oVGFF1mkRk2JLfFfckZlcPCg=";
     };
     "dad_carry_daughter.mp4" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/dad_carry_daughter.mp4";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/dad_carry_daughter.mp4";
       hash = "sha256-yU9Oi+S5qCkOGFPBS4u2MYCVUJN1+BmQX2NKCHyK2VU=";
     };
     "dancer.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/dancer.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/dancer.png";
       hash = "sha256-G6a6lmb2e8XsyrDDVF5iNm5y4WNlcpm5KTS6vpN3anA=";
     };
     "dancing_capybara.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/dancing_capybara.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/dancing_capybara.png";
       hash = "sha256-kpHKJMDc/rbVsGu/GHiGG6zN2XDd3WZrXtnS1pwHDOY=";
     };
     "dancing_women.mp4" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/dancing_women.mp4";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/dancing_women.mp4";
       hash = "sha256-Is80Ztdy/8y6+gsWKgGAdbl2sKH8mkljUO/Y+n8UO38=";
     };
     "deep_curl_portrait.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/deep_curl_portrait.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/deep_curl_portrait.png";
       hash = "sha256-WqPdXW23nbTT1iqfPko2XqCJeIwu7jW+9dOvDcn6ZgM=";
     };
     "deep_space_nexus.mp4" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/deep_space_nexus.mp4";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/deep_space_nexus.mp4";
       hash = "sha256-i2LkvD1zbrwaHzQo0tdgPzTt2ioAnCcK7+lW1lffWwk=";
     };
     "denim_girl.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/denim_girl.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/denim_girl.png";
       hash = "sha256-X68wNXAtJp1NHT97nsPvKY0TaBmFW89DF6SdzsBmZvI=";
     };
     "depth_controlnet_input_image.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/depth_controlnet_input_image.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/depth_controlnet_input_image.png";
       hash = "sha256-yhSAsCr8qnfZfCCOXMK3LCJH8teSe+xTaLG9sliER9k=";
     };
     "depth_t2i_adapter_input_image.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/depth_t2i_adapter_input_image.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/depth_t2i_adapter_input_image.png";
       hash = "sha256-PnVrZNMnu0vsQiqbGoIS4XewZDZ7xe7G0g4uXWU1wB0=";
     };
     "desert_oasis_backyard.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/desert_oasis_backyard.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/desert_oasis_backyard.png";
       hash = "sha256-z7R5Y40bHhOziCf3HvksPgWL12+U3lf250U6y8akkVo=";
     };
     "dieline.jpg" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/dieline.jpg";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/dieline.jpg";
       hash = "sha256-BZ2FGcLQGVbAEHpmLbi2OeLfeJAW8iMmv9Fua6K8Vbg=";
     };
     "digital_bloom.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/digital_bloom.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/digital_bloom.png";
       hash = "sha256-hPtqMwqTdLbK6TlOljN6ytMrDvyd6+H/eQBvDVntoy4=";
     };
     "dj_capybara.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/dj_capybara.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/dj_capybara.png";
       hash = "sha256-AiDJwp7vA3hHM6r5g/Maq4Sni5XMHDQ5jhKfvV/7Jfs=";
     };
     "downhill_run.jpg" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/downhill_run.jpg";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/downhill_run.jpg";
       hash = "sha256-jLOS0/6MpeCqinGweldPjk2WB96KQoyr498lQHf+QfQ=";
     };
     "dragon_fruit.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/dragon_fruit.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/dragon_fruit.png";
       hash = "sha256-1fz0gCYZEuTLPa02IM1ttcXAKbrhZ7lcKdUsUBynesI=";
     };
     "dragon_fruit_cream.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/dragon_fruit_cream.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/dragon_fruit_cream.png";
       hash = "sha256-yv1m9LhdMMTI5a97nziFKnJcQrdmuUwjoSA69sFGY4Y=";
     };
     "drinking_unicorn.mp4" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/drinking_unicorn.mp4";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/drinking_unicorn.mp4";
       hash = "sha256-0uPBQsEP3oItiBrG5pdEIVyadWL9yKrEYxzrGDR+qW4=";
     };
+    "drive_doll_street_dance.mp4" = {
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/drive_doll_street_dance.mp4";
+      hash = "sha256-IDR2tDs51cllxHu55axU3jEjape6s0y6U35O/i/c/h4=";
+    };
     "driving_outdoor_dance.mp4" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/driving_outdoor_dance.mp4";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/driving_outdoor_dance.mp4";
       hash = "sha256-KWFsWN25x++LERcxU+06tAUP11m/AHORqMRQe2SamZ0=";
     };
     "egyptian_queen.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/egyptian_queen.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/egyptian_queen.png";
       hash = "sha256-yikANilHBmSbYGzxqbFM6/WFPqyZS7SKecYqSVGrFEA=";
     };
     "empty_room_assembly.mp4" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/empty_room_assembly.mp4";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/empty_room_assembly.mp4";
       hash = "sha256-hj9jcVyaXgJkZVVUFcYPYDka0oMp2cVeJRfXR+MeuMI=";
     };
     "example.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/example.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/example.png";
       hash = "sha256-qOIVrTKgBS/EGQ6cWGNCjV7jXNmLJGJDhCuoNgURt8Q=";
     };
     "facing_the_dragon.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/facing_the_dragon.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/facing_the_dragon.png";
       hash = "sha256-xX22CP7XqIm9ZW4BGQJR0/Yqh25Sz70Qufj+bM1eFF0=";
     };
     "fighter_jet.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/fighter_jet.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/fighter_jet.png";
       hash = "sha256-Kly/QejnnOsemlp5yNdd/xUR/NXZbmIcJSz/Q4a4TY8=";
     };
     "flf2v_demo_first_frame.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/flf2v_demo_first_frame.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/flf2v_demo_first_frame.png";
       hash = "sha256-YTXhxoBm/IqZAVRU2AxaSqgi84IFfXO6TICMEzJiKAA=";
     };
     "flf2v_demo_last_frame.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/flf2v_demo_last_frame.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/flf2v_demo_last_frame.png";
       hash = "sha256-82ZIzOkvwBUeG95zNkCbF7rYL9V15cmioM2ERdhpWTk=";
     };
     "flower.mp4" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/flower.mp4";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/flower.mp4";
       hash = "sha256-2cm2saouM5Mw8AgOEqyv78dzPRNry0sVMU33eNwStPQ=";
     };
     "flower_sea.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/flower_sea.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/flower_sea.png";
       hash = "sha256-o/emLVJnZcS2Q8gqP6NrGrf2cSCMg45+QV9XNNokv/0=";
     };
     "fluffy_beige_sofa.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/fluffy_beige_sofa.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/fluffy_beige_sofa.png";
       hash = "sha256-WjpMUPxJJsGrel0z4uXcU2zZvfM6O3aaIzVhzDUoD04=";
     };
     "flux1_dev_uso_reference_image_gen_input_image.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/flux1_dev_uso_reference_image_gen_input_image.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/flux1_dev_uso_reference_image_gen_input_image.png";
       hash = "sha256-FPypwQhXMqDkTG6wqD2Xgbnz9mKnX+wLUMo0hjGhpJM=";
     };
     "flux_canny_model_example_input_image.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/flux_canny_model_example_input_image.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/flux_canny_model_example_input_image.png";
       hash = "sha256-a9GwG+npz1E9XefM2DvLkuU8+XtWh+32rwbkD6N54iE=";
     };
     "flux_depth_lora_example_input_image.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/flux_depth_lora_example_input_image.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/flux_depth_lora_example_input_image.png";
       hash = "sha256-ZV3BR6VEpuXYCLwNxHDUMLxZUkuKPvoNrwiHCGnmMqc=";
     };
     "flux_fill_inpaint_example_input_image.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/flux_fill_inpaint_example_input_image.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/flux_fill_inpaint_example_input_image.png";
       hash = "sha256-PPbMCWDfXVn3mgcFfrcye4eeNvgHyDrxsi/STtO35/g=";
     };
     "flux_fill_outpaint_example_input_image.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/flux_fill_outpaint_example_input_image.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/flux_fill_outpaint_example_input_image.png";
       hash = "sha256-QnnAnLLBzauSBGIshzVm75jd5B5h1gktO/8noWAWiPA=";
     };
     "flux_kontext_dev_basic_input_image.jpg" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/flux_kontext_dev_basic_input_image.jpg";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/flux_kontext_dev_basic_input_image.jpg";
       hash = "sha256-0oTft7YLQaIzgdBd1ad3WAeC+Unzdo1RoC9ouWSYiV4=";
     };
     "flux_redux_model_example_reference_image_1.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/flux_redux_model_example_reference_image_1.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/flux_redux_model_example_reference_image_1.png";
       hash = "sha256-tZ5as16Ak0wmUmBz5Hrqof3Wgn4iNb5+DBwCnuHbrP0=";
     };
     "flux_redux_model_example_reference_image_2.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/flux_redux_model_example_reference_image_2.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/flux_redux_model_example_reference_image_2.png";
       hash = "sha256-dbx2RFiJnQ8vjLgVXkjdvKLP6Mgv/Sj711aXQ7nVn7k=";
     };
     "forest_background.jpg" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/forest_background.jpg";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/forest_background.jpg";
       hash = "sha256-cz6RWAVnijOR8c+zxtNoca1L3+VIFQWbyGE7mzI5jb4=";
     };
     "frame_interpolation-input.mp4" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/frame_interpolation-input.mp4";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/frame_interpolation-input.mp4";
       hash = "sha256-RZQE3/9F4SVnh+mTBKu+XXuAgqsH7nVj3xM+WCjG98Q=";
     };
     "freckled_curly_girl.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/freckled_curly_girl.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/freckled_curly_girl.png";
       hash = "sha256-Qh3rE+6eKr1olayn78YhGfxjhV4pMfsIgrajXSkDoBc=";
     };
     "freezer.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/freezer.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/freezer.png";
       hash = "sha256-WU3SNLPjaMCIrvTJo7J4UT1Rx/wPiC+f9uMWOXp/kBo=";
     };
     "funny_dog.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/funny_dog.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/funny_dog.png";
       hash = "sha256-/G1wfMJtSUDv8sgkkInSa96Sl6m9XJPOaPRn6gQCEwQ=";
     };
     "furry_ball.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/furry_ball.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/furry_ball.png";
       hash = "sha256-BdLS4OFmmxrL40pO5vpxwG0hHcmoeH93SBNK8X6VFpc=";
     };
     "furry_tech.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/furry_tech.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/furry_tech.png";
       hash = "sha256-F/9bE/viDPJ1+1AYPGtlVOnDjwsUe7a3To7xHQVCiso=";
     };
     "future_portrait.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/future_portrait.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/future_portrait.png";
       hash = "sha256-jBngZrCQd+EmC5N463WVmh5Ac7I/0hu0nupjNJdhKok=";
     };
     "future_robot.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/future_robot.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/future_robot.png";
       hash = "sha256-ew4aCVUkg7F/oG2lrVin116Ja81DoKB3znDa7VJktIQ=";
     };
     "futuristic_motorcycle.mp4" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/futuristic_motorcycle.mp4";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/futuristic_motorcycle.mp4";
       hash = "sha256-QlJsLxGO6FVNxZILzHiFvf2BsVcWEPVclQaWKsRDwU4=";
     };
     "game_style.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/game_style.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/game_style.png";
       hash = "sha256-mYf5QqNqaT5S03oDAUQw+7TpNToYeGa8Y/R7+I/7H70=";
     };
     "gan_input.mp4" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/gan_input.mp4";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/gan_input.mp4";
       hash = "sha256-IO0LjxuIvI8GbiOS6GTWhRt5KfBWQd5SeNiCMuCvgWw=";
     };
     "gas_lamp.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/gas_lamp.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/gas_lamp.png";
       hash = "sha256-BRdddRFSXYwoiAhKPkD6nnom8rZ7LUAupIyhtIqulZo=";
     };
     "gel_cream_ad_voice.mp3" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/gel_cream_ad_voice.mp3";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/gel_cream_ad_voice.mp3";
       hash = "sha256-MCm459cuUmwuBNz6JhoNNQ1NrMNiVfjqaq2HdY1tuno=";
     };
     "german_shepherd_news_anchor_ref.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/german_shepherd_news_anchor_ref.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/german_shepherd_news_anchor_ref.png";
       hash = "sha256-ljx9H2EkwRIK1QplNEwfHcDMn+epvbuh0fcQbTnYoZo=";
     };
     "giant_trees_sky_pyramid.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/giant_trees_sky_pyramid.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/giant_trees_sky_pyramid.png";
       hash = "sha256-WDx1p80jZcUMQ04+Wh7BRdEm5Ncpe7303ZOxYC6/Ilg=";
     };
     "giant_tulip_wanderer.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/giant_tulip_wanderer.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/giant_tulip_wanderer.png";
       hash = "sha256-lndx8wq7OibmYw+Funobv9KsKSGB50JKrzRaaq6WwKM=";
     };
     "gimm-input.mp4" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/gimm-input.mp4";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/gimm-input.mp4";
       hash = "sha256-7XWtt0VfsoGey+QJtdbTu7u2yxcN4nKe5rHVDHrGdGA=";
     };
     "girl_and_fish.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/girl_and_fish.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/girl_and_fish.png";
       hash = "sha256-IISgaO5cWkbke37aXmh7eUZGluG2kPLV3oFvKkXjji0=";
     };
     "girl_eats_apple.mp4" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/girl_eats_apple.mp4";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/girl_eats_apple.mp4";
       hash = "sha256-CHWt10iyRjs7txO49dOv+a3QK7n5dIGCNya+0yEL7GU=";
     };
     "girl_holding_gel_cream.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/girl_holding_gel_cream.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/girl_holding_gel_cream.png";
       hash = "sha256-OoqBfdkLsI3f1qi+L3tvLD+6+CaaCXvwUZ8yXQJgfsE=";
     };
     "girl_lean_on_horse.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/girl_lean_on_horse.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/girl_lean_on_horse.png";
       hash = "sha256-At0vuU3Y5GAWTI5wZkfmMuSGxabh6ywIzvvUOB1SKBk=";
     };
     "girl_looking_at_photo.mp4" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/girl_looking_at_photo.mp4";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/girl_looking_at_photo.mp4";
       hash = "sha256-oYc7DHkDjTDnz9iN0SmaswoJZAzmQRhldvh0dNMEbAA=";
     };
     "girl_riding_a_wolf.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/girl_riding_a_wolf.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/girl_riding_a_wolf.png";
       hash = "sha256-Y9yLU9LKhRhdojgMwqc0F6k8Yf+y9eK5p17T6gIAzWs=";
     };
     "girl_riding_unicorn.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/girl_riding_unicorn.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/girl_riding_unicorn.png";
       hash = "sha256-VI7gUuqOW+HGpzGLxL0AtlczbaOZ84qAGE/qA8gxc2g=";
     };
     "goat_horned_spirit_girl.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/goat_horned_spirit_girl.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/goat_horned_spirit_girl.png";
       hash = "sha256-eX1Sa0Vx/xEZdXX3OPtNEE4K3pnQGHZ5sQFGf+hPCIQ=";
     };
     "goldenfish_in_bag.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/goldenfish_in_bag.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/goldenfish_in_bag.png";
       hash = "sha256-mdDvP+m7xDMN8HCpHA8k0q6MF/yuuc82csL83UEQbVM=";
     };
     "golf_ball_in_crocodile_mouth.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/golf_ball_in_crocodile_mouth.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/golf_ball_in_crocodile_mouth.png";
       hash = "sha256-3b3837M4kd5PUmDlrpYYmfasELNXP83GYsrBzfRJ+9Y=";
     };
     "gothic_hall_light_rays.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/gothic_hall_light_rays.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/gothic_hall_light_rays.png";
       hash = "sha256-Z8ehNM5zSVmHk30OfVsi5H2491GoHJQOgTdLVzv4AFg=";
     };
     "grainy_perfume_shot_crf32.mp4" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/grainy_perfume_shot_crf32.mp4";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/grainy_perfume_shot_crf32.mp4";
       hash = "sha256-BLxAjtFPHfrj06P2tCG+m80PUZKOJSt/p5nfqYgYO1s=";
     };
     "green_chiffon_short_dress.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/green_chiffon_short_dress.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/green_chiffon_short_dress.png";
       hash = "sha256-eTjSXQpuVYlkQciLsezdjyk9re9OwsGi2wg0fg/oOB4=";
     };
     "green_rider.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/green_rider.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/green_rider.png";
       hash = "sha256-ViOOiUrPBxXfZNmc0as0l9UAlgHhsE/V+EdqUbKM15g=";
     };
     "group_photo.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/group_photo.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/group_photo.png";
       hash = "sha256-iLhxH9+lcIA3NCqoAAXDT0YdwenkiOzFsZYdLS0DS14=";
     };
     "gs2_image1.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/gs2_image1.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/gs2_image1.png";
       hash = "sha256-IB16G+xa4LccN3xd+QKcTJRd9D+kWcUssLXL0UYGm7U=";
     };
     "gs2_image2.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/gs2_image2.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/gs2_image2.png";
       hash = "sha256-q4XSECXByl+S3DsOd2uPCTabSjBfMQ9rafRMT1Bctyo=";
     };
     "gs2_image3.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/gs2_image3.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/gs2_image3.png";
       hash = "sha256-2BTtJBRxDdB1QvM/+0shmGxGQKKpXzQE04nZ9QJCjjA=";
     };
     "gs2_image4.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/gs2_image4.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/gs2_image4.png";
       hash = "sha256-FxB1tbII8Xna7QVa5234wxhAGE12QNuTkZ2HZAv0hNI=";
     };
     "gsc3_car.jpeg" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/gsc3_car.jpeg";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/gsc3_car.jpeg";
       hash = "sha256-UnGgMH/6NcpJeiG/tsIxYaKwIcRBlxiYyDIRXYfbrWs=";
     };
     "gsc3_landscape.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/gsc3_landscape.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/gsc3_landscape.png";
       hash = "sha256-sxQXSUCXtm6AsppTe9CTeDXIkixj7B7nd+lEq6Yn2gg=";
     };
     "gsc_creator_2_2_input.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/gsc_creator_2_2_input.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/gsc_creator_2_2_input.png";
       hash = "sha256-mBk5dPLHPOJWL6HCORNVDCmAsy0C09RmQYXHc1cB0PU=";
     };
     "gsc_input_image_3_2.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/gsc_input_image_3_2.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/gsc_input_image_3_2.png";
       hash = "sha256-A9+GQghsVBsPSMaJSbl8oVqCMY88ThZxZZGMgn+VSdM=";
     };
     "gsc_input_video_3_2.mp4" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/gsc_input_video_3_2.mp4";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/gsc_input_video_3_2.mp4";
       hash = "sha256-86lUY/WuTchQLhV2KOED1Htqa9rxckpG/uXwNL2AvIU=";
     };
     "handbag_white.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/handbag_white.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/handbag_white.png";
       hash = "sha256-037DHurwaDLvWbCUjN16wJpbyWqVFhTFIH/BLmRuStQ=";
     };
     "heygen_input.mp4" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/heygen_input.mp4";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/heygen_input.mp4";
       hash = "sha256-hFGdGq69IMdYEWJphVL0aww52/WiSVE2MD5XByW/z70=";
     };
     "hidream_e1_1_input_image.jpg" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/hidream_e1_1_input_image.jpg";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/hidream_e1_1_input_image.jpg";
       hash = "sha256-cThRWI8GzJ7fL+0uDL/aRJTnb494dM1COfE/wX2sSbo=";
     };
     "hidream_e1_full_input_image.jpg" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/hidream_e1_full_input_image.jpg";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/hidream_e1_full_input_image.jpg";
       hash = "sha256-lf/N/sx0xmNRRnz5xMQunOHywyDzL9XvvNvqUzFNwto=";
     };
     "high_view_classic_car.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/high_view_classic_car.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/high_view_classic_car.png";
       hash = "sha256-4cRJ8smTEb2yTaN9UgFnMTQZgvc57q4EIoQ3o8caKF4=";
     };
     "hk_scene.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/hk_scene.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/hk_scene.png";
       hash = "sha256-wQZQN75OtCCz5bqfyuvCzmbddeE5DCWkAQM8NuK8Wl4=";
     };
     "horse_running.mp4" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/horse_running.mp4";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/horse_running.mp4";
       hash = "sha256-Ece2+rEFbRV3oBUAdbTYAPnLt4jzaQzAzUq3PZGtTJw=";
     };
     "hot_air_balloons_rising.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/hot_air_balloons_rising.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/hot_air_balloons_rising.png";
       hash = "sha256-wwxVIFl7a93cP7bzfvBDTrq9MmblM8rItosX/ECVxrA=";
     };
     "hovering_figure.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/hovering_figure.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/hovering_figure.png";
       hash = "sha256-KNFCklZid1k6KCQwzOeavYyaMdGWu5geAeJKd9touSo=";
     };
     "ice_cold_pup.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/ice_cold_pup.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/ice_cold_pup.png";
       hash = "sha256-ZdnoOD3TRzIyulPohgMyeO8TNe1LQrrHD1g0bNx/Cfw=";
     };
     "iced_drink_cup.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/iced_drink_cup.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/iced_drink_cup.png";
       hash = "sha256-aCk6FigThXyyBbxREaf2fR9BuhbqRl8I72Qdo730PNo=";
     };
     "iclora_input_resized_purz.mp4" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/iclora_input_resized_purz.mp4";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/iclora_input_resized_purz.mp4";
       hash = "sha256-SRc31FLLzZU0eu/LSbAzof5JDhxQCgirFZhbcw9TiiY=";
     };
     "illustration_bw.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/illustration_bw.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/illustration_bw.png";
       hash = "sha256-t0VmjaXKl0ukTNcwROy+DwWY3DsgBXZxzjnZNNyP8ng=";
     };
     "image2image_input_image.jpg" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/image2image_input_image.jpg";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/image2image_input_image.jpg";
       hash = "sha256-9StBf+r36LZbMYdenOvb+r74JK7Lvgs6mA+LVRum1SA=";
     };
     "image_chrono_edit_input_image.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/image_chrono_edit_input_image.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/image_chrono_edit_input_image.png";
       hash = "sha256-OXE6zsf66cinQLyRsubKO1N0wQC4weCuMobeRcO92v8=";
     };
     "image_flux.1_fill_dev_OneReward_input_image.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/image_flux.1_fill_dev_OneReward_input_image.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/image_flux.1_fill_dev_OneReward_input_image.png";
       hash = "sha256-VevagyeOEy6KTj1FXeZQaLAokmjxXn/szTQJZECgzco=";
     };
     "image_flux2_input_Illustration.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/image_flux2_input_Illustration.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/image_flux2_input_Illustration.png";
       hash = "sha256-QKuCevU6PQqN714POZUMr3+IkGxyuXx30anTDhPsm4A=";
     };
     "image_flux2_input_image.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/image_flux2_input_image.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/image_flux2_input_image.png";
       hash = "sha256-/kFtfPQIUG9uSKiKtT6/xh6hNSoU29F4fRwh1XS++4g=";
     };
     "image_flux2_input_ref_image.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/image_flux2_input_ref_image.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/image_flux2_input_ref_image.png";
       hash = "sha256-PraK9GGrUC3+ADi0ccgusvVc6EQgzprbLsIBhzWrlBY=";
     };
     "image_lotus_depth_v1_1_input_image.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/image_lotus_depth_v1_1_input_image.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/image_lotus_depth_v1_1_input_image.png";
       hash = "sha256-bVKPtGnLgpnVQN14qMTzK1dMDLPdDeGkgpyMLx8tFec=";
     };
     "image_omnigen2_image_edit_input_image.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/image_omnigen2_image_edit_input_image.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/image_omnigen2_image_edit_input_image.png";
       hash = "sha256-3XRY9eDkx6cP6QUmq3dFgLwZ8HUo0OvU2zup/pwRztg=";
     };
     "image_qwen_image_controlnet_patch_input_image.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/image_qwen_image_controlnet_patch_input_image.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/image_qwen_image_controlnet_patch_input_image.png";
       hash = "sha256-XNO5EDIGeHcqvBbQjjx3wjLA8O4pJAOTkov5TlEr3cU=";
     };
     "image_qwen_image_edit_2509_input_image-2.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/image_qwen_image_edit_2509_input_image-2.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/image_qwen_image_edit_2509_input_image-2.png";
       hash = "sha256-0ZyfQ8IOOP8u2T/Lag9TAl30SHDG2b5bSdVo+iO6YRc=";
     };
     "image_qwen_image_edit_2509_input_image.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/image_qwen_image_edit_2509_input_image.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/image_qwen_image_edit_2509_input_image.png";
       hash = "sha256-Nx2TvRp5fdhyeWKD11PC3wtNCIBRXFycEhP0gOOBJ54=";
     };
     "image_qwen_image_edit_input_image.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/image_qwen_image_edit_input_image.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/image_qwen_image_edit_input_image.png";
       hash = "sha256-aqYPFkzu8fuE1ldioLNDrcekEbwsYcKXCm4G5xMF9ZI=";
     };
     "image_qwen_image_instantx_controlnet_input_image.jpg" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/image_qwen_image_instantx_controlnet_input_image.jpg";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/image_qwen_image_instantx_controlnet_input_image.jpg";
       hash = "sha256-2q/Xf4GDbPA517SdC2npZ6l0CWfPUS2gzVtwBjsuRr0=";
     };
     "image_qwen_image_instantx_inpainting_controlnet_input_image.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/image_qwen_image_instantx_inpainting_controlnet_input_image.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/image_qwen_image_instantx_inpainting_controlnet_input_image.png";
       hash = "sha256-uNkkGduAwNDoNfLLlx6lQvY88t/TCrN7AFWDrJyL5LA=";
     };
     "image_qwen_image_union_control_lora_input_image.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/image_qwen_image_union_control_lora_input_image.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/image_qwen_image_union_control_lora_input_image.png";
       hash = "sha256-S1L0dxDtt6XrFAOnqQ9wHSFhSifRMpNGJLGIk7YfjLs=";
     };
     "image_to_video_input_image.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/image_to_video_input_image.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/image_to_video_input_image.png";
       hash = "sha256-cq5bJlp8d51WujZCep5zo1QenPmR7GLNFIdUqAlc9mg=";
     };
     "image_to_video_wan_start_image.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/image_to_video_wan_start_image.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/image_to_video_wan_start_image.png";
       hash = "sha256-1eOIKrmnAeFd4cZ6ibhZxxsjh8T7wTJXJPUgPqTokDc=";
     };
     "image_z_image_turbo_fun_union_controlnet_input_image.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/image_z_image_turbo_fun_union_controlnet_input_image.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/image_z_image_turbo_fun_union_controlnet_input_image.png";
       hash = "sha256-OHnVIKNCkTBID+5jaiYcp0PGmQdu4USsIoJObiY2+Bg=";
     };
     "indoor_portrait.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/indoor_portrait.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/indoor_portrait.png";
       hash = "sha256-PTl9pcYX1LX2Nko79GFp9Q5qAgXy+0bIaP4qqi041Po=";
     };
     "inflated_character.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/inflated_character.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/inflated_character.png";
       hash = "sha256-fD0JAh7fRpMZD3/mwzi5By4haWmvWtFpu+ch3SX69sQ=";
     };
     "inflation_lora_input.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/inflation_lora_input.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/inflation_lora_input.png";
       hash = "sha256-Auwr/0aha/OTV8LwjiDM+eA1fThxoo3AmQC90WPwijg=";
     };
     "inpaint_example_input_image.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/inpaint_example_input_image.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/inpaint_example_input_image.png";
       hash = "sha256-678kJVt5kHyQ/mkmlu6kH9vpgi1LvIrg9mAHnwqbRVk=";
     };
     "inpaint_model_outpainting_input_image.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/inpaint_model_outpainting_input_image.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/inpaint_model_outpainting_input_image.png";
       hash = "sha256-Oz2LO18bGvy8PIGeixO1o4WTkXDMEz2/yk8qIULkEDc=";
     };
     "input-aspect-ratio-converter" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/input-aspect-ratio-converter";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/input-aspect-ratio-converter";
       hash = "sha256-vVclgK9BlR91hEe0lL2UB1h66ybzdKuTc4qHzddFcAQ=";
     };
     "input-illustration_to_real-1.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/input-illustration_to_real-1.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/input-illustration_to_real-1.png";
       hash = "sha256-gcwfFL8PH9KTW+FyYkS46Prf76c8jzYeVQNGp+6BXrk=";
     };
     "input-sprite-1.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/input-sprite-1.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/input-sprite-1.png";
       hash = "sha256-vfs+g8j6vA7OJcjktznX85uljneWJnJojfLtPt1O+c4=";
     };
     "input_1-relight.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/input_1-relight.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/input_1-relight.png";
       hash = "sha256-mBabM/L24uWZCCZAhVCILjNkxhwR8y/Zkx6I6XZ3wWk=";
     };
     "input_2-relight.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/input_2-relight.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/input_2-relight.png";
       hash = "sha256-FHHEYd5cd8AeXquuDZ1D1hwZShcEAyDNVq7vepOd520=";
     };
     "input_3d.mp4" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/input_3d.mp4";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/input_3d.mp4";
       hash = "sha256-viLu+qMaGOcn3NX75+b39OeNGE6V9Ug6kRbTCQTqXfs=";
     };
     "input_3x3_contact_sheet.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/input_3x3_contact_sheet.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/input_3x3_contact_sheet.png";
       hash = "sha256-ZNM9BXtPxkRYjO8ejpuZrwtSgMh46WVjrFjTnPi36oo=";
     };
     "input_dearchive.mp4" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/input_dearchive.mp4";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/input_dearchive.mp4";
       hash = "sha256-pry8LCSHOVfuWf3QJTEN0Q0o+yIgQZyTGRJCtdDC56E=";
     };
     "input_face-1.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/input_face-1.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/input_face-1.png";
       hash = "sha256-LiiZOySgD2CzH/418ea/ls0RBfVzT6gc3JWnBK17Duo=";
     };
     "input_graphic-1x1.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/input_graphic-1x1.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/input_graphic-1x1.png";
       hash = "sha256-/f57g9fKdRinK8gtGSMcR0qFcMAMZGfRj7EwiYVrzDo=";
     };
     "input_playing_the_piano.mp4" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/input_playing_the_piano.mp4";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/input_playing_the_piano.mp4";
       hash = "sha256-dTxCU+2PkEIm0tsPhaUM2NKYecuYzpw9bng/jUAlChs=";
     };
     "input_reference_icon.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/input_reference_icon.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/input_reference_icon.png";
       hash = "sha256-C2EBZQ1NSSGUlRHfHQrIL0MkBUKaJ1aw2OOWa4YTnd4=";
     };
     "input_remove_watermark-1.mp4" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/input_remove_watermark-1.mp4";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/input_remove_watermark-1.mp4";
       hash = "sha256-rRUoXJ+45eLrMDHtqgaT98OlIlTnOUaVeZ21xRaWhCw=";
     };
     "input_storyboard_video.jpg" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/input_storyboard_video.jpg";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/input_storyboard_video.jpg";
       hash = "sha256-0SriGV5f80pgm4YUAEpM1DmJeuKNPPjHEvshFCcnUMs=";
     };
     "input_style_1.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/input_style_1.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/input_style_1.png";
       hash = "sha256-mjGtgKUABzLrPOt3l3XZkaXyTrMe9A4OGkPaCSZPX6w=";
     };
     "input_style_2.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/input_style_2.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/input_style_2.png";
       hash = "sha256-2fBxKGJvMW+oiqkRqpWG+Mp7ntJBa6u8OgG/Ti9YRZs=";
     };
     "input_style_3.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/input_style_3.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/input_style_3.png";
       hash = "sha256-4fRqK4bsw0tBwE6ebdsB2IyJzRu56D+Ge4gIDJfCf/s=";
     };
     "input_style_4.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/input_style_4.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/input_style_4.png";
       hash = "sha256-yZcJGuojXermzaDla29a8iSQoKELuyK3xfHSsJXiA+8=";
     };
     "input_style_5.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/input_style_5.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/input_style_5.png";
       hash = "sha256-sOFQbhQzYarn1a3YW8vcpHyvATEAVRaE3Vuaq/bcyHs=";
     };
     "input_subtitles-2.mp4" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/input_subtitles-2.mp4";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/input_subtitles-2.mp4";
       hash = "sha256-oV+K9DN50Hsp21wEzFX73N/Dado+M8mIqvvJuDuzGtY=";
     };
     "input_templates_rob_realistic_2k_images_quick_variations.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/input_templates_rob_realistic_2k_images_quick_variations.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/input_templates_rob_realistic_2k_images_quick_variations.png";
       hash = "sha256-FvQlsWlSwDU6YJV6ehgYq/ueNycgiDXrxG+/vTezbzU=";
     };
     "input_upscale.mp4" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/input_upscale.mp4";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/input_upscale.mp4";
       hash = "sha256-f4IB7DAXuhPOB96ca1Micaimze/Ltzi5qTf+PilIDH0=";
     };
     "interior_college.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/interior_college.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/interior_college.png";
       hash = "sha256-9Q3OlplIGy4vDGEE0P6GM98fu90C+K/xyYnoUmDEs0k=";
     };
     "investigator.mp4" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/investigator.mp4";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/investigator.mp4";
       hash = "sha256-DRha+Dsyr8QEMPWLwXlle8qIlYWbzKJK0YSIIO/31cA=";
     };
     "ivory_rider.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/ivory_rider.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/ivory_rider.png";
       hash = "sha256-hAOuVECexIZEG3Y1nB1l15wAVpahwB0VOF7BkRKMgus=";
     };
     "ivory_rider_left_side_view.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/ivory_rider_left_side_view.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/ivory_rider_left_side_view.png";
       hash = "sha256-4RBNNUTdOkv0LWVdxgeEMl9DHPFtNgHVbehCm9QQD0w=";
     };
     "ivory_rider_right_front_view.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/ivory_rider_right_front_view.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/ivory_rider_right_front_view.png";
       hash = "sha256-ZfwrXWzcWtxaUFBTY5UUIut5Oy5amj9q8KZubMDD1t4=";
     };
     "ivory_rider_right_side_view.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/ivory_rider_right_side_view.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/ivory_rider_right_side_view.png";
       hash = "sha256-OjbAM4kq03kRJPZ91+veqs+/r+1M2za8LAhCBxya5Uk=";
     };
     "japanese_street_alley.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/japanese_street_alley.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/japanese_street_alley.png";
       hash = "sha256-kyAnHKH63Q92nqXYX+JGSklorcczI4L51XkFZh0qnxY=";
     };
     "joker_back.jpg" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/joker_back.jpg";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/joker_back.jpg";
       hash = "sha256-QM+74krViHf1o/QX4KhWbqSul/RzMKQ584ogyf8PEKA=";
     };
     "joker_front.jpg" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/joker_front.jpg";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/joker_front.jpg";
       hash = "sha256-4lROnavniMiDr1c5E1MrP2KVsw8vE+WJwvXuHh/HRP8=";
     };
     "joker_side.jpg" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/joker_side.jpg";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/joker_side.jpg";
       hash = "sha256-JkIIe2jTUv9wTIfHOhVMrv+sl7tFU0s4jcdR13Z1/eI=";
     };
     "joy_snap.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/joy_snap.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/joy_snap.png";
       hash = "sha256-5HleZYKLVEOGvCtn442I5EqOQx7MwwRuXmP0UQ59eC0=";
     };
     "kitten_cop.mp4" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/kitten_cop.mp4";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/kitten_cop.mp4";
       hash = "sha256-BML9VtUfQVqY76/Uwe7bsJyLrmoT6eEhljuaBDQce68=";
     };
     "kling_avatar_input.mp3" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/kling_avatar_input.mp3";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/kling_avatar_input.mp3";
       hash = "sha256-4LE19o6XObHESq7NJ61mgyEUigcCy+7YvUBbe3OJg7I=";
     };
     "kling_o3_video_input.mp4" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/kling_o3_video_input.mp4";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/kling_o3_video_input.mp4";
       hash = "sha256-1ARWXKSg98nN8virNxyIE3ddMMF+msVLrQckaQyR2PU=";
     };
     "knight_with_sword.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/knight_with_sword.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/knight_with_sword.png";
       hash = "sha256-sBEkCcCrMPfWc/Tj0u4wfB7W2rIcVm3JfLr+ZEuMvwo=";
     };
     "krea2_reference_image.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/krea2_reference_image.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/krea2_reference_image.png";
       hash = "sha256-TCnqHdNdI+Ap6JoYvHOBj5GudLFmFw/ZcOOqolauoog=";
     };
     "krea_style_reference_image1.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/krea_style_reference_image1.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/krea_style_reference_image1.png";
       hash = "sha256-CvCGBHQNVG8uityOZYc4F03qVvf4HcUFauexGw/KF+o=";
     };
     "krea_style_reference_image2.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/krea_style_reference_image2.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/krea_style_reference_image2.png";
       hash = "sha256-QeNqPz4gIRr/fH2FGsgww6M3hkz2cKD0XEhOKcLjWDs=";
     };
     "latent_space_clud.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/latent_space_clud.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/latent_space_clud.png";
       hash = "sha256-j4mU+BKE6T41YMLvwi12UaUv18kXpnRvTDxAcq0fXzE=";
     };
     "lawyer.mp4" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/lawyer.mp4";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/lawyer.mp4";
       hash = "sha256-QWTqBYo9pP5qvAKvDwssuuPNSJC8rLTT8lnJe+QraXI=";
     };
     "leather_sofa.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/leather_sofa.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/leather_sofa.png";
       hash = "sha256-vkOH5zTxTFutPxMowXMdSsb4W5UXVmxN37HUSNltUcQ=";
     };
     "lego_street_panorama.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/lego_street_panorama.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/lego_street_panorama.png";
       hash = "sha256-rAMjLzCvTSsgdxWriwxSzuv7cIbcYQPN9iqGbHsHOxo=";
     };
     "leopard_rider.mp4" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/leopard_rider.mp4";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/leopard_rider.mp4";
       hash = "sha256-T/EzLP2qzhaeOPrtobBFhhwfS4YO2IEH3Idf1iOMLKY=";
     };
     "lighter.mp4" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/lighter.mp4";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/lighter.mp4";
       hash = "sha256-e3a0opvuD0YSSIncTP7kN0rM/Cmr19+VoD40Xp5ecEw=";
     };
     "lightning_man.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/lightning_man.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/lightning_man.png";
       hash = "sha256-py1qKvAiiByo+QzsGiNC0PqruEp29ZhkuOuPS6ex85Y=";
     };
     "lily_girl_blue.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/lily_girl_blue.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/lily_girl_blue.png";
       hash = "sha256-Cwbq2//yK/n5fKymu0YL4F8/1LxiFowh7rchznnn/ws=";
     };
     "little_bot.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/little_bot.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/little_bot.png";
       hash = "sha256-4U0u4QZiNdq0TjslSZJGqqs+Qq2hK2YQgHdgUta9bq0=";
     };
     "live_portrait_character.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/live_portrait_character.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/live_portrait_character.png";
       hash = "sha256-EY5Et0ifmZmPbykJyELLUEDMnokYk8ub1O5oo1HBscU=";
     };
     "live_portrait_expression.mp4" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/live_portrait_expression.mp4";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/live_portrait_expression.mp4";
       hash = "sha256-kSoC3P/vmxptZkHJpI4XBJAIDDcV3J9V2R4WhIPSfm4=";
     };
     "lizard_rapper_in_bar.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/lizard_rapper_in_bar.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/lizard_rapper_in_bar.png";
       hash = "sha256-zV0DPdbA9wbOMZDul+bjkl1tSRBae7yLjqa4aaQKHu8=";
     };
     "logotype_texture.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/logotype_texture.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/logotype_texture.png";
       hash = "sha256-OVjMegnmh4oDSbqjk6hT7M4SXU4I1yBUGwB/Fdxv8T4=";
     };
     "looped_restyler_init.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/looped_restyler_init.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/looped_restyler_init.png";
       hash = "sha256-GFCtzbGKDoD2NcKgrZA2T/X056IbcwTWvyPT2YArZg0=";
     };
     "low_angle_shot.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/low_angle_shot.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/low_angle_shot.png";
       hash = "sha256-io5ogiitBYRXToiR5JGB4aLbZuevKnRSWyDGEas2XdA=";
     };
     "low_view_classic_car.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/low_view_classic_car.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/low_view_classic_car.png";
       hash = "sha256-8Jw51oDBQOHvjfdiEYHRUoZ2DeWREIx/QsAebvpmUGE=";
     };
     "ltx2-a2v-input.mp3" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/ltx2-a2v-input.mp3";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/ltx2-a2v-input.mp3";
       hash = "sha256-Oc/qMB+x5vmANlVfJ64PR9nuA6UGvBgqIyrJCxgvpIA=";
     };
     "ltx2-a2v-input.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/ltx2-a2v-input.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/ltx2-a2v-input.png";
       hash = "sha256-M4IGxnA9UfVBnTScDzHYJuiKsPtO6SD7qFyWdpkfIqY=";
     };
     "ltx2.3_video_outpainting_input.mp4" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/ltx2.3_video_outpainting_input.mp4";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/ltx2.3_video_outpainting_input.mp4";
       hash = "sha256-X6QTaqi/O9VtwrLKLprDuBwCs78pcZlHKfstafq9RrM=";
     };
     "ltx23_flf2v_first_frame.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/ltx23_flf2v_first_frame.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/ltx23_flf2v_first_frame.png";
       hash = "sha256-DxEs+iemZzjo23glfovECku3/961lLI++0jOjz5X2Dk=";
     };
     "ltx23_flf2v_last_frame.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/ltx23_flf2v_last_frame.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/ltx23_flf2v_last_frame.png";
       hash = "sha256-Ksm9rMXIyj/A1F2aZSAAEZQstUlvU5NeCZieIhiNya4=";
     };
     "ltx23_reference_audio.mp3" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/ltx23_reference_audio.mp3";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/ltx23_reference_audio.mp3";
       hash = "sha256-CWqEJRZIYYAEI1Bb2sj6AClvhPNsBPAywXV/RoM8nas=";
     };
     "ltx_23_audio.mp3" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/ltx_23_audio.mp3";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/ltx_23_audio.mp3";
       hash = "sha256-Sg2P/QQhQ/zcsN5m4ue33QuxYaot/oLRqjEao95wjIs=";
     };
     "ltx_2_canny_1st_frame.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/ltx_2_canny_1st_frame.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/ltx_2_canny_1st_frame.png";
       hash = "sha256-sGbXt3QJk8dpi5SRJmc1aKYsnDNXBhxHOxPThU1W260=";
     };
     "ltxv_image_to_video_input_image.jpg" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/ltxv_image_to_video_input_image.jpg";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/ltxv_image_to_video_input_image.jpg";
       hash = "sha256-eQ9Dkm4Bz4Hc6q8JHp6M9eP8fASf+7IGjDRvDOTgM2g=";
     };
     "lucky_cat_sculpture_front.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/lucky_cat_sculpture_front.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/lucky_cat_sculpture_front.png";
       hash = "sha256-rid6QcQ3W0FxVh/p0YfRhRF+f4dNtEX6sDgYxpwhlcE=";
     };
     "magical-portrait.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/magical-portrait.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/magical-portrait.png";
       hash = "sha256-uUtszH35G/6a5+kMP6D0wX7VO6pbDByS/iwtRPtNdMg=";
     };
     "magnific_style_reference.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/magnific_style_reference.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/magnific_style_reference.png";
       hash = "sha256-IydN70w5lkiTxwRaPOISggSPsMBYtUCPLjKOhwjnF6w=";
     };
     "man_3x3_contact_sheet.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/man_3x3_contact_sheet.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/man_3x3_contact_sheet.png";
       hash = "sha256-UcmfQgtg6FSGqIbtWJ308scnwLSTIPq+ckgr1SonTUY=";
     };
     "man_in_daydream.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/man_in_daydream.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/man_in_daydream.png";
       hash = "sha256-kAqvoEDs49Z8kv0jWeBT+4iGv0h3epImeH6xrJi005A=";
     };
     "man_in_street.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/man_in_street.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/man_in_street.png";
       hash = "sha256-1wgWh8bJ4XNEjUWctJnC+yCABZsf1mVrsN4tVx7XJqw=";
     };
     "man_in_the_rain.mp4" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/man_in_the_rain.mp4";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/man_in_the_rain.mp4";
       hash = "sha256-gqRbF3IbNbT8CaBNVq9pC3/Pwk6KAGcmIVh9Ra3w4+I=";
     };
     "man_on_desert.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/man_on_desert.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/man_on_desert.png";
       hash = "sha256-whBp9CsHkjTchwo39/JqayRFySWQiQ3FIDGVBnlwx4w=";
     };
     "man_playing_violin.mp4" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/man_playing_violin.mp4";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/man_playing_violin.mp4";
       hash = "sha256-FoYPOPzvZa2ASZ1sf4EVBC269rE4nt5pKV2pLLux6l4=";
     };
     "man_ref.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/man_ref.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/man_ref.png";
       hash = "sha256-QkiYNN/wq+a7Rnhm1yTQ/F67sp8l3/6fIPF88WGZgIk=";
     };
     "man_with_dog.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/man_with_dog.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/man_with_dog.png";
       hash = "sha256-hcbPy/0oOuDuHWQPyMlQmjoC4B6TO4OfG/y82c/erLc=";
     };
     "man_with_old_computers.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/man_with_old_computers.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/man_with_old_computers.png";
       hash = "sha256-c+z43v1g+2fSpjoENWPaM6/SKuc1OpGi7mqsb3PJFcg=";
     };
     "man_with_red_hat.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/man_with_red_hat.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/man_with_red_hat.png";
       hash = "sha256-XspXvEMnAqmZO3PsuuEm6zac2iXpHN/ljLLym/yw4BM=";
     };
     "man_with_rose.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/man_with_rose.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/man_with_rose.png";
       hash = "sha256-6kbDdp1d7gp//Df4H8wTSQlCDwjWpwV6jIrdpDnnoTg=";
     };
     "mecha_dragon_lightning.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/mecha_dragon_lightning.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/mecha_dragon_lightning.png";
       hash = "sha256-8upYOHE5qhrM8BuRoUWnVqc4VGGO3ktD7phiJdkUxbM=";
     };
     "medusa_poster.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/medusa_poster.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/medusa_poster.png";
       hash = "sha256-rX7liFccHD3DDFlm7AvdrR8yTmg+SPSMojjX3897LX4=";
     };
     "melbandroformer_input.mp3" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/melbandroformer_input.mp3";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/melbandroformer_input.mp3";
       hash = "sha256-tbNcoZAiDVZDo6gVm6eMNtc7ETIeD4zTE1JJGSxUcYw=";
     };
     "midnight_coastal.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/midnight_coastal.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/midnight_coastal.png";
       hash = "sha256-Hvwdc5pptG36UT5dFHzMk70+Ke2Bq4XYvR2X5MJFLx8=";
     };
     "minimalist_sky_view_lounge.mp4" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/minimalist_sky_view_lounge.mp4";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/minimalist_sky_view_lounge.mp4";
       hash = "sha256-iIUmj68r4Fiel8IDf6PnuGnu1qF7SiA8gRn/DfJKTTk=";
     };
     "minimalist_sky_view_lounge.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/minimalist_sky_view_lounge.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/minimalist_sky_view_lounge.png";
       hash = "sha256-oahzVt/+6WJSN7ckQhi09WZBSnDgQ/CU8YfwTTR8WlI=";
     };
     "minimalist_wooden_sofa_living_room.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/minimalist_wooden_sofa_living_room.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/minimalist_wooden_sofa_living_room.png";
       hash = "sha256-z9AAx6PWD/K5BnCf+oTlF0CPRunLMF/hpdq0p5BfTpk=";
     };
     "mixing_controlnets_pose_input.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/mixing_controlnets_pose_input.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/mixing_controlnets_pose_input.png";
       hash = "sha256-bf8jZZtQ825j0kK9yoQBFlkMgpJivtHVqBmWJ5AHCRI=";
     };
     "mixing_controlnets_scribble_input.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/mixing_controlnets_scribble_input.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/mixing_controlnets_scribble_input.png";
       hash = "sha256-ZNohZPw0CuwdVNR5o/tMiTmG78x3RSv04IO2xFEBHiE=";
     };
+    "model_blue_outfit.png" = {
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/model_blue_outfit.png";
+      hash = "sha256-STfLX/dUn1yoYj3hYm8La6k2RrIwhwoETmiESuVEF9o=";
+    };
     "modern_living_room.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/modern_living_room.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/modern_living_room.png";
       hash = "sha256-So43Y0oTGfrVCtUWRAuWPq1RlzvC5tErMX9zpzThKeo=";
     };
     "moonlit_cliff_house.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/moonlit_cliff_house.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/moonlit_cliff_house.png";
       hash = "sha256-sqYb8Ee6Wr7+R2BR4ckpOi4mA3SxG3GZBGtQMlU8VqI=";
     };
     "motor_cycle.fbx" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/motor_cycle.fbx";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/motor_cycle.fbx";
       hash = "sha256-bX8R78qT2y7OdWz/VEKObddhdpvu/g9hL1AiqQqk64M=";
     };
     "nb2-single_image_sprite_sheet-input" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/nb2-single_image_sprite_sheet-input";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/nb2-single_image_sprite_sheet-input";
       hash = "sha256-rQT2tfbpXL5nmvZKal/DRCAFqH8vIzFwSord6P4nfAE=";
     };
     "neon_cyborg_portrait.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/neon_cyborg_portrait.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/neon_cyborg_portrait.png";
       hash = "sha256-mDR0AAqOlvHlOKd4PNCc5yHD2K4q7gklKdWIEpqmZ6A=";
     };
     "neon_guitarist.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/neon_guitarist.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/neon_guitarist.png";
       hash = "sha256-g+Yzg9FxWnCEr7XPHi5H4wKGnCyUS/pi2G52m0/2Xsw=";
     };
     "ninja.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/ninja.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/ninja.png";
       hash = "sha256-Jt7AOkgjSe9Ea662YeFmmc8Y4YXcisGqGwVCDBTGEqw=";
     };
     "noir_portrait.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/noir_portrait.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/noir_portrait.png";
       hash = "sha256-mpy39XPaOS2VIlStBFXs2aAKSpv6OgmY/HgkOBydIPI=";
     };
     "noisy_background.mp3" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/noisy_background.mp3";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/noisy_background.mp3";
       hash = "sha256-CrfiCTRQpNVZ1vuQKT+FDZTsmodUYEb0Z9eB/n3P7J8=";
     };
     "normals_input.mp4" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/normals_input.mp4";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/normals_input.mp4";
       hash = "sha256-VKxbNsuQe05lxT5vCdlI3TxOUUpenBTaOmZkTFbj8ZQ=";
     };
     "nun_in_church-1.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/nun_in_church-1.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/nun_in_church-1.png";
       hash = "sha256-wnS17j1iMLBJwbienwWbEdFmPyw1lS6h59TJwIFwr34=";
     };
     "nun_in_church-2.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/nun_in_church-2.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/nun_in_church-2.png";
       hash = "sha256-4CXRlHM984zT4SAsMPFAsWtBUSeAHeeyQXpK+BBNErk=";
     };
     "old_bear.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/old_bear.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/old_bear.png";
       hash = "sha256-Q171XrqQmHN42IIff8trJK5+jVgiXelwCfhQp+EkH+A=";
     };
     "old_man_dancing.jpg" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/old_man_dancing.jpg";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/old_man_dancing.jpg";
       hash = "sha256-gHDPQ9QJ4QXq2nW4S5KzzKvOOtGbQ5XhfBh64sH+q30=";
     };
     "old_school_style_girl.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/old_school_style_girl.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/old_school_style_girl.png";
       hash = "sha256-mBk5dPLHPOJWL6HCORNVDCmAsy0C09RmQYXHc1cB0PU=";
     };
     "orange_beauty_trio.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/orange_beauty_trio.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/orange_beauty_trio.png";
       hash = "sha256-3qN/30fP612Wo6iCfswDX/ELmdgCDTiQl4wEVptpiks=";
     };
     "outfit-streetwear.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/outfit-streetwear.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/outfit-streetwear.png";
       hash = "sha256-e1wHTlsOmPCiXeUFFXCc0leuFhnl4Zm0KBhuLfmZwQk=";
     };
     "outfit-templates_rob_fashion_shoot_vton-4in1.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/outfit-templates_rob_fashion_shoot_vton-4in1.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/outfit-templates_rob_fashion_shoot_vton-4in1.png";
       hash = "sha256-O8aqtGqB8WeLygj56tqaqu29ce5qu1jrulT22OnUfCs=";
     };
     "outfit.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/outfit.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/outfit.png";
       hash = "sha256-ItLaeBPxcvEIhNNGligUvoU5kn6TkFns+h7wX/TACSY=";
     };
     "outfit_image-2.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/outfit_image-2.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/outfit_image-2.png";
       hash = "sha256-DMDyZgLdFn4RszFbi76hEvuim/ZR+FufwLx3opK7nlA=";
     };
     "path_of_the_cube.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/path_of_the_cube.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/path_of_the_cube.png";
       hash = "sha256-f/RFLysN59694KZshEsIqQHamNJjnHtn9QbRhvyH2d8=";
     };
     "perfume_bottle.png.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/perfume_bottle.png.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/perfume_bottle.png.png";
       hash = "sha256-2DUNbnPdgXO4JKQmyb4ep4yrtOV7WKmWLLXwMwkNCbM=";
     };
     "perfume_orange_shot.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/perfume_orange_shot.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/perfume_orange_shot.png";
       hash = "sha256-ZTYf3d4ZuPqaGtr9YcLN+PCExpRiYdSDjI+MYH9KgC0=";
     };
     "phone.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/phone.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/phone.png";
       hash = "sha256-Dr30/eiSewQDwjzkaX+MMINZM7JgEvFz+j54RK3gIyk=";
     };
     "pink_city_horse.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/pink_city_horse.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/pink_city_horse.png";
       hash = "sha256-rupolgTFKwdf15sg1XRNMj+HA6FcY3zSLgFJtpslijU=";
     };
     "pink_hair_mech_arms_ref.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/pink_hair_mech_arms_ref.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/pink_hair_mech_arms_ref.png";
       hash = "sha256-l47OQIabVx+6xDD1YKjU+RdKoKy969B0lXoHDcSAuX8=";
     };
+    "pink_lipstick.png" = {
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/pink_lipstick.png";
+      hash = "sha256-3PsPqhSaFmiNrgwuydtPwKvMps2NOVYRqbfLsKHdeJQ=";
+    };
     "pink_robot_back.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/pink_robot_back.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/pink_robot_back.png";
       hash = "sha256-Gwn3cQFrbZtUSo4tAsOuNpZzi25L0huNDvE39xwgfzs=";
     };
     "pink_robot_front.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/pink_robot_front.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/pink_robot_front.png";
       hash = "sha256-H7U44kMYPq8f5bak2CK/RP72+4Doxebj5dompDhdCWU=";
     };
     "pink_tone_chair.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/pink_tone_chair.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/pink_tone_chair.png";
       hash = "sha256-Y1YwPbNE2JRyP24+drRYopv0QHRSLbR03XYoJfXgu0s=";
     };
     "pirates_dancing.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/pirates_dancing.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/pirates_dancing.png";
       hash = "sha256-CYPRHfzLkH1oJEjwA2lLf5dgjileCNUArLFbzqFjohI=";
     };
     "play_chess.mp4" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/play_chess.mp4";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/play_chess.mp4";
       hash = "sha256-TZwkJhnfFy1wK1myLIuMVzTN22BT/vVVhR02wtVBfgM=";
     };
     "playful_portrait.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/playful_portrait.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/playful_portrait.png";
       hash = "sha256-yiC8thZ+qzBv8sIC24TSd7Fli2NLQ+cTDOMIqdh8m88=";
     };
     "pool_end_frame.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/pool_end_frame.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/pool_end_frame.png";
       hash = "sha256-7PK4xzkxi+K6ZUwViHZEpvfuQLrObwBjCCA4t4uoMp4=";
     };
     "pool_start_frame.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/pool_start_frame.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/pool_start_frame.png";
       hash = "sha256-Hb7v6aqoBtRMr2ywUjpnxyKeRl2tw5y0ws3wE92lgeo=";
     };
     "porsche_car_01.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/porsche_car_01.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/porsche_car_01.png";
       hash = "sha256-+Z4HRIpPU++sg6RojFEjtv+Dunyj3WbielkPZpsv7XQ=";
     };
     "porsche_car_02.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/porsche_car_02.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/porsche_car_02.png";
       hash = "sha256-294TcES+SKAj1GBs+CWFCrz6oNJmtYvXikBzmVqoHT8=";
     };
     "portrait_floral_headshot.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/portrait_floral_headshot.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/portrait_floral_headshot.png";
       hash = "sha256-UxjuXf20bx4osWzsKgzeSXr2I6XAnAS6aLIxRSEjKlA=";
     };
     "pose_input.mp4" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/pose_input.mp4";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/pose_input.mp4";
       hash = "sha256-gxRpeVnByFs9QxLCim7mIbReK9YAXpxEKtJNgo8QvRU=";
     };
     "pray.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/pray.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/pray.png";
       hash = "sha256-lnGowwAyvlPwzBAoYmEuEtZR59knln81zSEq3zhkmI8=";
     };
     "prince_and_phoenix.mp4" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/prince_and_phoenix.mp4";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/prince_and_phoenix.mp4";
       hash = "sha256-1ARWXKSg98nN8virNxyIE3ddMMF+msVLrQckaQyR2PU=";
     };
     "product-cleanser.jpeg" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/product-cleanser.jpeg";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/product-cleanser.jpeg";
       hash = "sha256-sLl0CZEewHbvL203wUrnFs3sHDgD+Mm8GC+oC4Xnz28=";
     };
     "product-toothbrush.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/product-toothbrush.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/product-toothbrush.png";
       hash = "sha256-KKxSgfsv/el6UeQPK0dUDV/qdcgKkqB/s9+CyF3as8o=";
     };
     "product_1_product_placement.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/product_1_product_placement.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/product_1_product_placement.png";
       hash = "sha256-5Pkl71zKCBVMoGisW192vg6az0IbMLmmC0UPxms3v5o=";
     };
     "product_2_product_placement.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/product_2_product_placement.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/product_2_product_placement.png";
       hash = "sha256-ZHOXltP06XM/wuI/YejYcgdHNdsZcFvHw8WwkkmoeBo=";
     };
     "product_3_product_placement.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/product_3_product_placement.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/product_3_product_placement.png";
       hash = "sha256-V5jY9bFzQEIKpgKI4Y1E2Gk6BNJ731P88iF+LIhTkGE=";
     };
     "product_car.jpg" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/product_car.jpg";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/product_car.jpg";
       hash = "sha256-X4b9knKKBYqxEbwS/rJI+ykl39mQOHr7SpBQItaw8A4=";
     };
     "product_photo.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/product_photo.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/product_photo.png";
       hash = "sha256-grC5YTYofaHRia8wEMQ93TO/9h0fztjjM3qsGsuSVsU=";
     };
     "product_shoe.jpeg" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/product_shoe.jpeg";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/product_shoe.jpeg";
       hash = "sha256-CTMUkZqXGj5B4Byq7ogIPdOpMV53jG+ti8THHdwG9Yg=";
     };
     "product_shoe.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/product_shoe.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/product_shoe.png";
       hash = "sha256-isedz8+rphO004PdSSi/P6UqcYdU8GuCMWYgTzYIlCA=";
     };
     "projection_light_portrait.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/projection_light_portrait.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/projection_light_portrait.png";
       hash = "sha256-NHoe7IelbLtDOB7HiHL9fcJaJXpykcmpgNIl3p459rg=";
     };
     "puppy_with_blue_bandana.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/puppy_with_blue_bandana.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/puppy_with_blue_bandana.png";
       hash = "sha256-V8gWYimH0vn1lAazlTbTZZ99LgJkmoHcSREunWDJJqM=";
     };
     "quiet_girl.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/quiet_girl.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/quiet_girl.png";
       hash = "sha256-/Az4tLQzcMPvswp2mELOfFsdQPz71UXQI2QgyHLRLVc=";
     };
     "quokka_bath.jpg" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/quokka_bath.jpg";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/quokka_bath.jpg";
       hash = "sha256-pY+wZAAoku7+LIYYNyLVXKXLP81URX6/AdAg9apS/Eo=";
     };
     "quokka_relax.jpg" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/quokka_relax.jpg";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/quokka_relax.jpg";
       hash = "sha256-2UJwlQ1LXg2LJitTptxVu55zOYW+bjNnA2Krt3rbmqI=";
     };
     "raccoon_rocker.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/raccoon_rocker.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/raccoon_rocker.png";
       hash = "sha256-HqH8helNabUl/ez1fdJ8rVy7qYiDNJh/Vb97scl4w3M=";
     };
     "rapper_on_cliff_with_moon.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/rapper_on_cliff_with_moon.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/rapper_on_cliff_with_moon.png";
       hash = "sha256-pO1v17BwORJvZUayMLq4/+JOgVKbokA0LqNMGjE7wkw=";
     };
     "real_human_demo.mp4" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/real_human_demo.mp4";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/real_human_demo.mp4";
       hash = "sha256-nZWbNpR3AFGXpxCj27zkYviJsbKhmufI3D0uClQBzCQ=";
     };
     "real_human_demo.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/real_human_demo.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/real_human_demo.png";
       hash = "sha256-vcauqSTSzMmG4adIw5hC+KKU73NlZfffx/gyhNS7OQc=";
     };
     "recraft_style_ref-1.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/recraft_style_ref-1.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/recraft_style_ref-1.png";
       hash = "sha256-wskUiRTUwi5s5oKmiB37feRMpgzNBrLwtDhoXcb/aTQ=";
     };
     "recraft_style_ref-2.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/recraft_style_ref-2.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/recraft_style_ref-2.png";
       hash = "sha256-GJ4zJh6dLASpe51att2EEZ3rAh/KqSJCiPEMFmL5Hhk=";
     };
     "recraft_style_ref-3.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/recraft_style_ref-3.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/recraft_style_ref-3.png";
       hash = "sha256-vCHUQ6kK60cI0DbZfsydVslRlZg8VgrI9XSZICc0JT4=";
     };
     "recraft_style_ref-4.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/recraft_style_ref-4.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/recraft_style_ref-4.png";
       hash = "sha256-x9WroH4KCgKbXGfmoT0R+WhbMJmJUZ0RdIdBHzGfahc=";
     };
     "red_car.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/red_car.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/red_car.png";
       hash = "sha256-u87/LYi3ybMxS6IRHI55SwH2WiqiwoEDAUaqX45BqRg=";
     };
     "red_f1_track_car.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/red_f1_track_car.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/red_f1_track_car.png";
       hash = "sha256-yEfFIPicpu8o57pdmIXGNFs9oe7B2rb14DD7HwxCuVc=";
     };
     "red_haired_girl.jpg" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/red_haired_girl.jpg";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/red_haired_girl.jpg";
       hash = "sha256-Ld949sGP6V+SHdx8z4z2/9MxbSf+ji0vK9bfxHcMy9w=";
     };
     "red_panda.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/red_panda.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/red_panda.png";
       hash = "sha256-lgBtUljVw2fTQKGXYnskoBiz5GdloGbTVFKpkp9jGFg=";
     };
+    "red_sports_car_night.png" = {
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/red_sports_car_night.png";
+      hash = "sha256-igrw2Eg+LNI2n7MdJ6qf3HG4blZTvq8pMSF2K/W1Ykg=";
+    };
     "red_superboy_on_city_roof.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/red_superboy_on_city_roof.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/red_superboy_on_city_roof.png";
       hash = "sha256-4eWjx1gHLbwsqYc/368RJIjBJpPtmm6lo7bWu9HC/qc=";
     };
+    "ref_doll_realistic.png" = {
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/ref_doll_realistic.png";
+      hash = "sha256-QqWKVxkKbn/7SmIGsdbwG2/JWEW2DYsg+QU6rv8W4z8=";
+    };
     "reference_ad.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/reference_ad.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/reference_ad.png";
       hash = "sha256-GK6bTlUEpXtHgmW9r3fyQUMFvQrJqmgj6iT4MdF8liQ=";
     };
     "reference_image_product_placement.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/reference_image_product_placement.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/reference_image_product_placement.png";
       hash = "sha256-7/B2QslPxFqG+ljfttF95i0Dih0ZlyR1cEW9/03fZew=";
     };
     "reference_poster.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/reference_poster.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/reference_poster.png";
       hash = "sha256-+wb/6+LmvB/ntZTuE34o0PSYguftRVVVeeNfwftI+D0=";
     };
     "reference_streetwear_character.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/reference_streetwear_character.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/reference_streetwear_character.png";
       hash = "sha256-bEkKk7BT+hhOqy8ABO0BCHKwSl2ei5A38VuryVJHxdw=";
     };
     "retro_futuristic_home.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/retro_futuristic_home.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/retro_futuristic_home.png";
       hash = "sha256-EqnVhGGaKI25YcbxnTGaRdxzGaILiML9H1ldr5VPPRE=";
     };
+    "retro_girl_cinnamon_bun.png" = {
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/retro_girl_cinnamon_bun.png";
+      hash = "sha256-re+Y1AMjRO60UPwYC3oX4hRybSgvS3iwIOyxkpixPeE=";
+    };
     "robed_women.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/robed_women.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/robed_women.png";
       hash = "sha256-5ey7Aw15ndjzC0GWwre2AcSvt1B6m49EKz3H0Y2fFOk=";
     };
     "robot-warrior.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/robot-warrior.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/robot-warrior.png";
       hash = "sha256-O5Fpe3R8LQ6igrjZLROJGsi8ME+x28cIqydZungdmoQ=";
     };
+    "robot_hand.png" = {
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/robot_hand.png";
+      hash = "sha256-2sh76oSyhWMQhLXeaMJuFK9XX6R1xpy0zewaz6Yf7V0=";
+    };
     "robot_hand_back.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/robot_hand_back.png";
-      hash = "sha256-c72iNwZir8QTkLHH26eBcmYNFpcn5evPdF8vYwzBSug=";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/robot_hand_back.png";
+      hash = "sha256-2sh76oSyhWMQhLXeaMJuFK9XX6R1xpy0zewaz6Yf7V0=";
     };
     "robot_hand_energy.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/robot_hand_energy.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/robot_hand_energy.png";
       hash = "sha256-WPs+YQFbUne/CrO+100lHJJjHedWyikRONg7n2QEW/E=";
     };
     "robot_nun_pray.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/robot_nun_pray.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/robot_nun_pray.png";
       hash = "sha256-YcFXWeaA5zEGnutmYgMJezkeeJboNZOvRjvT2kbBKvw=";
     };
     "robot_office_worker_in_space.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/robot_office_worker_in_space.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/robot_office_worker_in_space.png";
       hash = "sha256-BdwhI2qjy20WGPDcsz40ulKcg58ieo/RYfDwMpdgpOo=";
     };
     "roller_coaster.mp4" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/roller_coaster.mp4";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/roller_coaster.mp4";
       hash = "sha256-7aeEhp5G02yWu4zuoN38eVJntl+ANwIDAnuVNHvTurs=";
     };
     "running_horse.mp4" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/running_horse.mp4";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/running_horse.mp4";
       hash = "sha256-+wavTya9+3VjA3E5F0GK87brHJN4LmuoTQQc+e0O2ag=";
     };
     "safari_outfit.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/safari_outfit.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/safari_outfit.png";
       hash = "sha256-HkpHkuQpX9gMor91B0Oxti59+FImRNNI5RJs7PDJBNQ=";
     };
     "sci-fi_mech.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/sci-fi_mech.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/sci-fi_mech.png";
       hash = "sha256-1bHd95QVlTdOnTXTtGO/pWuYVZsQO1RnBP6HEUhezNY=";
     };
     "sd3.5_large_blur_input_image.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/sd3.5_large_blur_input_image.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/sd3.5_large_blur_input_image.png";
       hash = "sha256-LgiE0IjXv3k16Du6lnYRrYEqgqG2nf8bvm5mAoGpwdw=";
     };
     "sd3.5_large_canny_controlnet_example_input_image.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/sd3.5_large_canny_controlnet_example_input_image.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/sd3.5_large_canny_controlnet_example_input_image.png";
       hash = "sha256-lLQ9UUmIF4NKXRLalSY0Y8lSN8NqLyM3Bf0FRlwJHAY=";
     };
     "sd3.5_large_depth_input_image.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/sd3.5_large_depth_input_image.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/sd3.5_large_depth_input_image.png";
       hash = "sha256-DcQmisZx1CungoxQ2m5zDnim1/eNSqZBQp11BZUpSfk=";
     };
     "sd_first_frame.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/sd_first_frame.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/sd_first_frame.png";
       hash = "sha256-bVxMaNq7YYlu99VR82Gd0Q1sz9lwG+ju/cubCBq/5GE=";
     };
     "sd_last_frame.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/sd_last_frame.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/sd_last_frame.png";
       hash = "sha256-ra5VhO/9rAyfws3xsiQ+JQ/9LKMfn1H3Guyl0wdwbrU=";
     };
     "sd_outfit_1.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/sd_outfit_1.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/sd_outfit_1.png";
       hash = "sha256-WOKb+ycpVp02t7TAXDKuID0HhpEizG4xjcjVXQwXaVE=";
     };
     "sd_outfit_2.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/sd_outfit_2.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/sd_outfit_2.png";
       hash = "sha256-NSURKVMQWrSdhyuqG4kJ7WeJEA5ZZVLp5wX+D4w5+14=";
     };
     "sd_outfit_3.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/sd_outfit_3.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/sd_outfit_3.png";
       hash = "sha256-Eg8vCgy+d/TeifLFtUwrzUX9Kdar/KfgQkbot6w9jTw=";
     };
     "sdxl_revision_text_prompts_ref_image1.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/sdxl_revision_text_prompts_ref_image1.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/sdxl_revision_text_prompts_ref_image1.png";
       hash = "sha256-vsexTh5veCMK3cZEhSfT9T7oX8mGd82cYpMtE5yx1K4=";
     };
     "sdxl_revision_text_prompts_ref_image2.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/sdxl_revision_text_prompts_ref_image2.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/sdxl_revision_text_prompts_ref_image2.png";
       hash = "sha256-5OzySXpJaETiYtc4pU+dW1FdgMg8PTRniooag84MdUs=";
     };
     "seamless_loop_input.mp4" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/seamless_loop_input.mp4";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/seamless_loop_input.mp4";
       hash = "sha256-QN6EEzuawIEtRCaSFfC/pgTv0Js29cITn/qOLU5a1Fo=";
     };
     "seed_audio_ref_audio1.mp3" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/seed_audio_ref_audio1.mp3";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/seed_audio_ref_audio1.mp3";
       hash = "sha256-cl/glBR8b1mXDXAIEPqFyiMP3u2F3DWj1qe5qKT/nH8=";
     };
     "selfie_cartoon_style.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/selfie_cartoon_style.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/selfie_cartoon_style.png";
       hash = "sha256-dug+WVk47d4h4oOx3LDvifOo0egVrkQfsOb/OMcbTos=";
     };
     "shane_video_restyle_ref_frame.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/shane_video_restyle_ref_frame.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/shane_video_restyle_ref_frame.png";
       hash = "sha256-t2D/p7dlMJ8AujCqMGsSVuUY/t0NPr3CpCD+JLF8drE=";
     };
     "sheep_knit.jpg" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/sheep_knit.jpg";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/sheep_knit.jpg";
       hash = "sha256-VUj/0lV+WE4fpU8isunNgAOPBbwAJAs3vZZcYmCl4ng=";
     };
     "silent_sanctuary.jpg" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/silent_sanctuary.jpg";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/silent_sanctuary.jpg";
       hash = "sha256-rnCEhMPGYlLfG0Z1Q8oWrzAaz3PjVPltpUhP20bl6Jk=";
     };
     "silver_hand.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/silver_hand.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/silver_hand.png";
       hash = "sha256-scOk5C9hmptqldMahku0dwwFyFyF0TUamH5bDkLBDpA=";
     };
     "simple_modern_living_space.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/simple_modern_living_space.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/simple_modern_living_space.png";
       hash = "sha256-W2I7A/c0l95WEG3ZZ8pvifwuR3od4VzVjnoF+OFtcKE=";
     };
+    "sloth_bullfight.mp4" = {
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/sloth_bullfight.mp4";
+      hash = "sha256-tVjHLritAMlTuGCab+Izcyy0iEWmq5iaQ4J1C1LOyfI=";
+    };
     "snake_detector.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/snake_detector.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/snake_detector.png";
       hash = "sha256-mtyrRrknlpj5e9ZMh7tB81P4cmqTTIt2EtNaQCAbNqU=";
     };
     "snake_on_jacket.jpg" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/snake_on_jacket.jpg";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/snake_on_jacket.jpg";
       hash = "sha256-4D8HhhrAgnyXVjMteNEfkJnRzOE4xxJ8fakcLPElMW0=";
     };
     "snow_bike_jump_crew.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/snow_bike_jump_crew.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/snow_bike_jump_crew.png";
       hash = "sha256-BtvIMqR9nndmzswvu6/N9tWz8rjTC7QEBr5l5P82dyM=";
     };
     "snowboard_rush.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/snowboard_rush.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/snowboard_rush.png";
       hash = "sha256-xqP8Cvut8h4SG9Jv7Y6ipTW8E5IP6WmbrEf1FLnW5eA=";
     };
     "snowboarder.mp4" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/snowboarder.mp4";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/snowboarder.mp4";
       hash = "sha256-cMqCv3iootuhd7//reNVQ5ikT1GwpvGIaT0SzEiPO08=";
     };
     "snowboarder.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/snowboarder.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/snowboarder.png";
       hash = "sha256-c2vFeUeQzo2TqnQ7GT6mMoV9U/ZQCN6V/V8dv71ZB/M=";
     };
     "soft_light_headphones_man.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/soft_light_headphones_man.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/soft_light_headphones_man.png";
       hash = "sha256-iC9dT1sCepIwNRROfcIwfEoJFv5sClJcyzBwrl1fmSU=";
     };
     "soft_neon_girl.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/soft_neon_girl.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/soft_neon_girl.png";
       hash = "sha256-EbfGjm4EtMlaJUNlgkubZlbrnByhmeijoBqqvmqXUg8=";
     };
     "source_ref_video.mp4" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/source_ref_video.mp4";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/source_ref_video.mp4";
       hash = "sha256-tr1CUzLS4r1R65hCazO35cVU9sabRsnSIQqag2Jrxgk=";
     };
     "space_battle.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/space_battle.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/space_battle.png";
       hash = "sha256-YCZF1i5/nMXAgVayznh2Cq7jdBgN1thiPzw4yuaPZWQ=";
     };
     "space_caravan.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/space_caravan.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/space_caravan.png";
       hash = "sha256-fRBlAxnFvhOOtUwKiHgYnNbFJU0ac1fncV6B1x6JiT8=";
     };
     "space_horse_rider.mp4" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/space_horse_rider.mp4";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/space_horse_rider.mp4";
       hash = "sha256-lK3HvuJcCHjyg0RoSsBlFbLoosO6JIBIp2XAyjpxbZk=";
     };
     "spear_warrior.mp4" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/spear_warrior.mp4";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/spear_warrior.mp4";
       hash = "sha256-nP2vx0UlzY64/Pb0yUBLJ1KWaTBkyrWCgQ2focIfw3k=";
     };
     "sportbike_rider.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/sportbike_rider.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/sportbike_rider.png";
       hash = "sha256-fvjkwyBhOJw5HBySbTbmE4lf9x8XDST1NQNfalNZQfg=";
     };
     "squirrel_in_flower_garden.mp4" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/squirrel_in_flower_garden.mp4";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/squirrel_in_flower_garden.mp4";
       hash = "sha256-cRsWjljWtOUf94ca9+1skxPAWn9bAwSt+XYMkwOMj68=";
     };
     "stained_window_vintage_woman.mp4" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/stained_window_vintage_woman.mp4";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/stained_window_vintage_woman.mp4";
       hash = "sha256-ga1OEiAcKzhLxh8rv0oP1pg3lM7QOy//Iwqojx0qQGk=";
     };
     "steampunk_woman_underwater.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/steampunk_woman_underwater.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/steampunk_woman_underwater.png";
       hash = "sha256-WmRyyNqJ/873VR5mxcLQB0QRgcTJsb8C+WDNCeXUokc=";
     };
     "steel_in_the_mist.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/steel_in_the_mist.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/steel_in_the_mist.png";
       hash = "sha256-y+1r/92CBA3GDDnH+M52K5I770/wnm5XmRDgDQMnPfU=";
     };
     "stone_ruins.mp4" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/stone_ruins.mp4";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/stone_ruins.mp4";
       hash = "sha256-KTnNt+I163MBhfKdoKjepDU13A4dUxgpDY7RInqjIG4=";
     };
     "storyboard_input.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/storyboard_input.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/storyboard_input.png";
       hash = "sha256-nudWfllR1PgzgRTuMGglRp6f3Tiya6otRuqCamFe/R8=";
     };
     "street_dance_drive.mp4" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/street_dance_drive.mp4";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/street_dance_drive.mp4";
       hash = "sha256-r/yMR0potcF8nzjYCvxolgZXesCVGpUJfTPxMAbJC9g=";
     };
     "street_dancer.mp4" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/street_dancer.mp4";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/street_dancer.mp4";
       hash = "sha256-/g22opGKO37x2XBGZNTyMmif/RMQyKriwh4mEyDD5M4=";
     };
     "streetwear_fox.jpg" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/streetwear_fox.jpg";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/streetwear_fox.jpg";
       hash = "sha256-FAlhPd9wYZNcWNGPSdqGYI0UpoSbL1vbLLKJVH/daRE=";
     };
     "subject-1.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/subject-1.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/subject-1.png";
       hash = "sha256-uzUUyDzapzCgROeUSISqWIZZQROlOwDI2d3rnysh6BU=";
     };
     "subject-elderly-lady-portrait.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/subject-elderly-lady-portrait.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/subject-elderly-lady-portrait.png";
       hash = "sha256-LYyGLdIEdM88YQyXUTAioq6MwpmegXrWu7SQf0S51o0=";
     };
     "subject-girl-holding-skincare-bottle.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/subject-girl-holding-skincare-bottle.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/subject-girl-holding-skincare-bottle.png";
       hash = "sha256-RgNqPi/c1s8uTLlszV7CmqKovxTVKIEJ9tUBZdAvmcI=";
     };
     "subject-profile.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/subject-profile.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/subject-profile.png";
       hash = "sha256-oPzknvwy87EVzKH1m9Y6K+byH7cGTjVrbvKugry3/NI=";
     };
     "subject-templates_rob_fashion_shoot_vton-4in1.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/subject-templates_rob_fashion_shoot_vton-4in1.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/subject-templates_rob_fashion_shoot_vton-4in1.png";
       hash = "sha256-W6qiKc861HvaKMmJS/hvQgXlU5nkC1ELHjcX3ec9wk8=";
     };
     "subject.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/subject.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/subject.png";
       hash = "sha256-UC4bd3RaUoJuOs7VHeyWl2a7PtM937UieKVdkff/X3c=";
     };
     "subject_close.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/subject_close.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/subject_close.png";
       hash = "sha256-gAXqtFn/8YyuM1u7y1mDrdUkrjynJkE5MEMAxM971pQ=";
     };
     "subject_far.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/subject_far.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/subject_far.png";
       hash = "sha256-Q94ywyiCWm9Mpnz1x44p/XS5CdWPEMBCl/kk5aqrO08=";
     };
     "subject_leopard_hair_croc_jacket.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/subject_leopard_hair_croc_jacket.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/subject_leopard_hair_croc_jacket.png";
       hash = "sha256-2s+JA4ZIFULEssTe94w+Z6yZtO/d1YHxQ+j90H1RzaI=";
     };
     "subway_guitar_busker.mp4" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/subway_guitar_busker.mp4";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/subway_guitar_busker.mp4";
       hash = "sha256-FtjCZXLtuEJEo8R0vKI7OJwoVTTPyktuW7umntU3To8=";
     };
     "suit_3x3_contact_sheet.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/suit_3x3_contact_sheet.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/suit_3x3_contact_sheet.png";
       hash = "sha256-GTHS0F6fQmuwtdGBmqLLZsHQFTF2/omxcN6QjCn2pqE=";
     };
     "sunlit_girl_portrait.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/sunlit_girl_portrait.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/sunlit_girl_portrait.png";
       hash = "sha256-7h9oEoOuy83ixg6yuuctFknKBgMP5WaHrklyYigWNVA=";
     };
     "sunlit_rooftop_capture.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/sunlit_rooftop_capture.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/sunlit_rooftop_capture.png";
       hash = "sha256-OISFIRKuWYP9kWRSwl5UNOEXnFX4hv3LLkX26ZD+CWo=";
     };
     "sunset_city_skateboarder.mp4" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/sunset_city_skateboarder.mp4";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/sunset_city_skateboarder.mp4";
       hash = "sha256-VwYTT0fes8u/KOdaeVAk2+QZSll8OOvmDuxdK+rixJg=";
     };
     "sync3_reference_audio.mp3" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/sync3_reference_audio.mp3";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/sync3_reference_audio.mp3";
       hash = "sha256-FeXf0WThYB2ByOKUYeUOJBgng3DgjD0venlfRPvnink=";
     };
     "tech_cowboy.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/tech_cowboy.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/tech_cowboy.png";
       hash = "sha256-dVx/MjfoA4KVCm4hVEYzhIAkEaCfL14TxdSzv1Jzla0=";
     };
     "template-3x3_Grid_For_Product_Ads Assets.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/template-3x3_Grid_For_Product_Ads%20Assets.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/template-3x3_Grid_For_Product_Ads%20Assets.png";
       hash = "sha256-N6WzNJr4vwtJAbP+sEkmdy6N+RIcHCvlUYURettPHtY=";
     };
     "template-Magazine_Cover_&_Packag_Design.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/template-Magazine_Cover_%26_Packag_Design.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/template-Magazine_Cover_%26_Packag_Design.png";
       hash = "sha256-LZSHf9u8g1wxmJUkVHKmq4pkGO+siPUwx6bSvAvb64o=";
     };
     "template_Poster_Scene_Mockups.jpg" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/template_Poster_Scene_Mockups.jpg";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/template_Poster_Scene_Mockups.jpg";
       hash = "sha256-0HF8NFPt4IEfftjQJ49CBEzKq8GOPpiKkFn0mSV+tdU=";
     };
     "template_eric_exploded_view_first_frame.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/template_eric_exploded_view_first_frame.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/template_eric_exploded_view_first_frame.png";
       hash = "sha256-YpO8Y7ryTTzCq0NenuR4wdEbTURMn4AIOlakFTyAiTI=";
     };
     "template_eric_exploded_view_last_frame.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/template_eric_exploded_view_last_frame.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/template_eric_exploded_view_last_frame.png";
       hash = "sha256-cdoF+7u75dpsRmCVhkIYYxeeNBu+di9hh0RutgYd+kE=";
     };
     "template_image_speech_to_video_woman_holding_face_oil.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/template_image_speech_to_video_woman_holding_face_oil.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/template_image_speech_to_video_woman_holding_face_oil.png";
       hash = "sha256-XcV5tKfFTYVB9npwCCrKY8FP/KTziV/PX3rW1+V5saI=";
     };
     "templates-character_sheet_pink_silver_outfit.jpg" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/templates-character_sheet_pink_silver_outfit.jpg";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/templates-character_sheet_pink_silver_outfit.jpg";
       hash = "sha256-3TwGj+Pr3Y6TYsc0p93q+yW7eH3d752ULN13l2+4xaM=";
     };
     "templates-sprite_sheet_input-sprite-1.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/templates-sprite_sheet_input-sprite-1.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/templates-sprite_sheet_input-sprite-1.png";
       hash = "sha256-vfs+g8j6vA7OJcjktznX85uljneWJnJojfLtPt1O+c4=";
     };
     "templates_mjm_image_to_3d.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/templates_mjm_image_to_3d.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/templates_mjm_image_to_3d.png";
       hash = "sha256-kG0VlhWPAsmOppKhIALJa+Wq5OHKANu962zhyA5JO0M=";
     };
     "templates_purz_crossfade_crossfade_clip_1.mp4" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/templates_purz_crossfade_crossfade_clip_1.mp4";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/templates_purz_crossfade_crossfade_clip_1.mp4";
       hash = "sha256-NPm2DohS4HqiILkt2rbBIK+T5pBpyeOQCNtKDPFgFWk=";
     };
     "templates_purz_crossfade_crossfade_clip_2.mp4" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/templates_purz_crossfade_crossfade_clip_2.mp4";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/templates_purz_crossfade_crossfade_clip_2.mp4";
       hash = "sha256-p5WCJbdusm/8GG+OHHsdsAnofsKvRrEzau97gKU8OHM=";
     };
     "templates_purz_wan22_animate_auto_full_scene.mp4" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/templates_purz_wan22_animate_auto_full_scene.mp4";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/templates_purz_wan22_animate_auto_full_scene.mp4";
       hash = "sha256-nHM2kyAC/8hXu4LsVOv08y+TH6bIDKClpvFAIxcSPN8=";
     };
     "templates_rob_image_to_real-input.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/templates_rob_image_to_real-input.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/templates_rob_image_to_real-input.png";
       hash = "sha256-db/XcaexnDQyL4szFP6OHyYbHxdQqHd6xVFrKbENp04=";
     };
     "texture_fur.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/texture_fur.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/texture_fur.png";
       hash = "sha256-boN/Z4DxseVnTqsk+CisKSDifrj5966DWDt30FfX3Hg=";
     };
     "the_forgotten_gate.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/the_forgotten_gate.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/the_forgotten_gate.png";
       hash = "sha256-H8XfRlwy5n9C0Z9i5FOZiP2Cz66XFrB+rzERzhXJeFQ=";
     };
     "the_leap.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/the_leap.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/the_leap.png";
       hash = "sha256-6GtjzHMYAbMoiVvIt0/D+1M2EJPRxepuCKM3q36y/+s=";
     };
     "the_lily_veil.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/the_lily_veil.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/the_lily_veil.png";
       hash = "sha256-jBU1GQ80MOYFkjQnjhQkqeLyzjlyimL2gvJHIGbM6aQ=";
     };
     "tokyo_street.mp4" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/tokyo_street.mp4";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/tokyo_street.mp4";
       hash = "sha256-tDr+nZH1MKnHLmak0vzUvjSakonkiXMAjIQxhLfJttg=";
     };
     "toy.glb" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/toy.glb";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/toy.glb";
       hash = "sha256-iL9cLLKGic+3TMKGMzLdHoqnFZVFzHNt6bmzK7+2pOA=";
     };
     "transparent_rgb_gaming_mouse.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/transparent_rgb_gaming_mouse.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/transparent_rgb_gaming_mouse.png";
       hash = "sha256-SWlnSNL/8OjJtjxxc8bWKCtw6sAZXe9bOUAvlWRBDnU=";
     };
     "tv_head.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/tv_head.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/tv_head.png";
       hash = "sha256-VK9PYK292gkL2COv+tUdTF2Ma/YLTWyCQ/4GgJUE3O8=";
     };
     "two_character_talking.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/two_character_talking.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/two_character_talking.png";
       hash = "sha256-iKnXvTgyMEpbZmJsRCiG8Lgt284XYInlBLiur0zDMz4=";
     };
     "two_characters.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/two_characters.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/two_characters.png";
       hash = "sha256-bPEnut+SRKQKyv7MsNilZihkDAGmzv55pjLPgHcdRAg=";
     };
     "uni_1_style_ref.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/uni_1_style_ref.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/uni_1_style_ref.png";
       hash = "sha256-DFjANWyeENq1jrf7n0diOFLsihrP6XTIY+t1ywpQwEU=";
     };
     "urban_man.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/urban_man.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/urban_man.png";
       hash = "sha256-iIb/bM02lzniJydK+K1C0PhicSnYPBZDyE49oTSMqYY=";
     };
     "utility-audioseparation-audio-input.mp3" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/utility-audioseparation-audio-input.mp3";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/utility-audioseparation-audio-input.mp3";
       hash = "sha256-lKvD15M5HEbs14loiPlYVSMXjW8lWSLIsZU6ZXNgS00=";
     };
     "utility-lineart-video-input.mp4" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/utility-lineart-video-input.mp4";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/utility-lineart-video-input.mp4";
       hash = "sha256-Z5UTG5EIuJotD4Fdj1DjqPBeMF1cQjVieKCl1saBoL0=";
     };
     "utility_gimm_frame_interpolation_gimm-input.mp4" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/utility_gimm_frame_interpolation_gimm-input.mp4";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/utility_gimm_frame_interpolation_gimm-input.mp4";
       hash = "sha256-7XWtt0VfsoGey+QJtdbTu7u2yxcN4nKe5rHVDHrGdGA=";
     };
     "victory_cover.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/victory_cover.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/victory_cover.png";
       hash = "sha256-AAnz33O8ceZ9K87XCso8hz8+qyZOjimu8iD7LNH6j5Q=";
     };
     "video_humo_input_audio.wav" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/video_humo_input_audio.wav";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/video_humo_input_audio.wav";
       hash = "sha256-TpIIktPTPruKBNdylgoCfxhfpVITzgxgz9DsP68ZHo8=";
     };
     "video_humo_reference_image.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/video_humo_reference_image.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/video_humo_reference_image.png";
       hash = "sha256-OmZi66CcELctdjy5R8o45xeZi6/FXX0MFPcqFBDuHrA=";
     };
     "video_hunyuan_video_1.5_720p_i2v_input_image.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/video_hunyuan_video_1.5_720p_i2v_input_image.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/video_hunyuan_video_1.5_720p_i2v_input_image.png";
       hash = "sha256-8lAqnITcI3m920RM/ZXgBX8J0zAO6z8RzpNkdIxmW14=";
     };
     "video_wan2.1_fun_camera_v1.1_1.3B_start_image.jpg" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/video_wan2.1_fun_camera_v1.1_1.3B_start_image.jpg";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/video_wan2.1_fun_camera_v1.1_1.3B_start_image.jpg";
       hash = "sha256-/PYZEO01bQ9s4FIanmZJ/qIhBYdOBT2EfW33q59uptU=";
     };
     "video_wan2.1_fun_camera_v1.1_14B_start_image.jpg" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/video_wan2.1_fun_camera_v1.1_14B_start_image.jpg";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/video_wan2.1_fun_camera_v1.1_14B_start_image.jpg";
       hash = "sha256-5CsKCe2E2Qwn6Wwp7nVZCK48vdsuLgFVMWzNQ44wt8o=";
     };
     "video_wan2_2_14B_animate_original_video.mp4" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/video_wan2_2_14B_animate_original_video.mp4";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/video_wan2_2_14B_animate_original_video.mp4";
       hash = "sha256-YA2ShjHZEmYdwPwWStDBR2wVqsBamjU6XKfdlmy5Nzg=";
     };
     "video_wan2_2_14B_animate_reference_image.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/video_wan2_2_14B_animate_reference_image.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/video_wan2_2_14B_animate_reference_image.png";
       hash = "sha256-mkYSY6vUJ55xv/YxpQvcoYCezxUFZGYo386nPyVI7Rg=";
     };
     "video_wan2_2_14B_flf2v_end_image.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/video_wan2_2_14B_flf2v_end_image.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/video_wan2_2_14B_flf2v_end_image.png";
       hash = "sha256-nMzPhtUBvwIroo1EnJxBujg87wQWSlBKyFwJc/NBzO0=";
     };
     "video_wan2_2_14B_flf2v_start_image.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/video_wan2_2_14B_flf2v_start_image.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/video_wan2_2_14B_flf2v_start_image.png";
       hash = "sha256-9Qpjq2q1QGw5Pdfyl/l5O6OcHwiLxnm3vRikMdjk73g=";
     };
     "video_wan2_2_14B_fun_camera_start_image.jpg" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/video_wan2_2_14B_fun_camera_start_image.jpg";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/video_wan2_2_14B_fun_camera_start_image.jpg";
       hash = "sha256-IdA73u+9qfD1Jdg8lF3AgjJrGeBtI5Wh0ajLiTaCRx8=";
     };
     "video_wan2_2_14B_fun_control_start_image.jpg" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/video_wan2_2_14B_fun_control_start_image.jpg";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/video_wan2_2_14B_fun_control_start_image.jpg";
       hash = "sha256-f078fvVKMomsFBs9PY+pOpNK4UgAdWKuds/mkSU+j4E=";
     };
     "video_wan2_2_14B_fun_control_start_image_control_video.mp4" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/video_wan2_2_14B_fun_control_start_image_control_video.mp4";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/video_wan2_2_14B_fun_control_start_image_control_video.mp4";
       hash = "sha256-8Xs8yRKH1miZgbYkvnZDu5dcXzUEUuEbPmSab/0ySVQ=";
     };
     "video_wan2_2_14B_fun_inpaint_end_image.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/video_wan2_2_14B_fun_inpaint_end_image.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/video_wan2_2_14B_fun_inpaint_end_image.png";
       hash = "sha256-ZOhYTL4am5VKAlmdqZ2+dAymjYQMRgisanG9oAPfO2M=";
     };
     "video_wan2_2_14B_fun_inpaint_start_image.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/video_wan2_2_14B_fun_inpaint_start_image.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/video_wan2_2_14B_fun_inpaint_start_image.png";
       hash = "sha256-Sip4aVFcP4iHcH+lZ2Api9RRSVYOkGDR72CC/WafUu8=";
     };
     "video_wan2_2_14B_i2v_input_image.jpg" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/video_wan2_2_14B_i2v_input_image.jpg";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/video_wan2_2_14B_i2v_input_image.jpg";
       hash = "sha256-u32aN9qx9Qj3I1jlc8YSEpYuM3xE1RHDKF22cMUp4O8=";
     };
     "video_wan2_2_14B_s2v_input_audio.MP3" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/video_wan2_2_14B_s2v_input_audio.MP3";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/video_wan2_2_14B_s2v_input_audio.MP3";
       hash = "sha256-BrU8d36/JDPEIpBEHoe+2uoXp9zuG2r+47YsjpZ76ls=";
     };
     "video_wan2_2_14B_s2v_reference_image.jpg" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/video_wan2_2_14B_s2v_reference_image.jpg";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/video_wan2_2_14B_s2v_reference_image.jpg";
       hash = "sha256-zKFDzkYQtckeo0ZbEQAe8/AxZ0HggUHulCy8211daYE=";
     };
     "video_wan2_2_5B_fun_control_control_video.mp4" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/video_wan2_2_5B_fun_control_control_video.mp4";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/video_wan2_2_5B_fun_control_control_video.mp4";
       hash = "sha256-/aWvd7LQGOuPMK69OkH/woGICvCUYE0ZpcBAbVX2k5I=";
     };
     "video_wan2_2_5B_fun_control_start_image.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/video_wan2_2_5B_fun_control_start_image.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/video_wan2_2_5B_fun_control_start_image.png";
       hash = "sha256-4ZrPfVPkV6g8k1PACgMIMLK+88MRMZjSI16wwoyipDA=";
     };
     "video_wan2_2_5B_fun_inpaint_end_image.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/video_wan2_2_5B_fun_inpaint_end_image.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/video_wan2_2_5B_fun_inpaint_end_image.png";
       hash = "sha256-hGttylHtW/X+f2tdp6bFdB/KpU5bA9y8WOUXYVQejHM=";
     };
     "video_wan2_2_5B_fun_inpaint_start_image.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/video_wan2_2_5B_fun_inpaint_start_image.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/video_wan2_2_5B_fun_inpaint_start_image.png";
       hash = "sha256-J5LnNl5r2kck8wEojx2oWO68kVxu7dUVF3oWhKt2l1Q=";
     };
     "video_wan_animate2.mp4" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/video_wan_animate2.mp4";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/video_wan_animate2.mp4";
       hash = "sha256-kB40ZJ9n66RElwLMJ39VCtOuHksRctpIRolFTeKizjQ=";
     };
     "video_wan_ati_input_image.jpg" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/video_wan_ati_input_image.jpg";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/video_wan_ati_input_image.jpg";
       hash = "sha256-bXOXVVfWxjnuXgVUOGH9DGLoBNx0xvzBLwA6+AKEwLE=";
     };
     "video_wan_vace_14B_ref2v_reference_image.jpg" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/video_wan_vace_14B_ref2v_reference_image.jpg";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/video_wan_vace_14B_ref2v_reference_image.jpg";
       hash = "sha256-TSjYsviHjq7oLGS59nWrMcCyIWE4hA1cPMJ94C5okGQ=";
     };
     "video_wan_vace_14B_v2v_reference_image.jpg" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/video_wan_vace_14B_v2v_reference_image.jpg";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/video_wan_vace_14B_v2v_reference_image.jpg";
       hash = "sha256-B8Ok+zQBDojkRv+oWFQ7yl0rnNn5k/ppxYiSDha9OIE=";
     };
     "video_wan_vace_14B_v2v_reference_image_control_video.mp4" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/video_wan_vace_14B_v2v_reference_image_control_video.mp4";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/video_wan_vace_14B_v2v_reference_image_control_video.mp4";
       hash = "sha256-/00FNekObM3z0MBOjPjuHZZ+k7VTysgw4xAwiQwPaR4=";
     };
     "video_wan_vace_flf2v_end_image.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/video_wan_vace_flf2v_end_image.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/video_wan_vace_flf2v_end_image.png";
       hash = "sha256-Oiaai0GT4KH+SBSjpKnMuZ2HnK+8Kr2pXOR6xlvG+iQ=";
     };
     "video_wan_vace_flf2v_start_image.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/video_wan_vace_flf2v_start_image.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/video_wan_vace_flf2v_start_image.png";
       hash = "sha256-VdcFhHesdmGXU8f6rn/phnN80Magr887NRUj7TCnScU=";
     };
     "video_wan_vace_inpainting_1st_frame_and_mask.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/video_wan_vace_inpainting_1st_frame_and_mask.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/video_wan_vace_inpainting_1st_frame_and_mask.png";
       hash = "sha256-eaMCTb+vk8nfq56QZdszu6u5yNbwV5dSR8Ef8pjaWRs=";
     };
     "video_wan_vace_inpainting_input_video.mp4" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/video_wan_vace_inpainting_input_video.mp4";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/video_wan_vace_inpainting_input_video.mp4";
       hash = "sha256-L2ir7bFciZr48opobg8v1FouBx/N9z1vO6hwLT9NEHY=";
     };
     "video_wan_vace_inpainting_reference_image.jpg" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/video_wan_vace_inpainting_reference_image.jpg";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/video_wan_vace_inpainting_reference_image.jpg";
       hash = "sha256-B+B07v14EWIhSpo1zfsYtY2ZdFlPbHV6Ic8CQBLzqF4=";
     };
     "video_wan_vace_outpainting_input_video.mp4" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/video_wan_vace_outpainting_input_video.mp4";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/video_wan_vace_outpainting_input_video.mp4";
       hash = "sha256-DSMg0cweB1MJLADKvlTYTOhXCRVeJWwQPeEwDTUN/Q8=";
     };
     "view.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/view.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/view.png";
       hash = "sha256-PeH3lHAuPP/mYh9ufoGV4c173VD3HFzeLBqvNcd1pK4=";
     };
     "vintage-girl.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/vintage-girl.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/vintage-girl.png";
       hash = "sha256-qpOUHd8NyWN6m1JukozY/GB4OE8bRo7cW4zo/JLnluw=";
     };
     "vintage_field_style_look.mp4" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/vintage_field_style_look.mp4";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/vintage_field_style_look.mp4";
       hash = "sha256-2ZD+Y1JmC4Nds4wcn3SEDrnkTKjo9OcB3mvZR5hlm/0=";
     };
+    "vintage_girl_yellow_apple.png" = {
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/vintage_girl_yellow_apple.png";
+      hash = "sha256-G6ZEr8TliuCLvgblnFdAAbXXwYVPBayHUcy8fhrfBHI=";
+    };
     "vintage_portrait.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/vintage_portrait.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/vintage_portrait.png";
       hash = "sha256-fbdLrJzzVQxjhh8mGWwNVeoF9/ZL5bV0Y1qnDdtL+mA=";
     };
     "vintage_robot.jpg" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/vintage_robot.jpg";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/vintage_robot.jpg";
       hash = "sha256-J7GrDmrD1DPKckCONie1hDi50S5txW5cTyWeUaiqH18=";
     };
     "vintage_thinker.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/vintage_thinker.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/vintage_thinker.png";
       hash = "sha256-FnOteqoSFdSh1uECzMcZXzoFaXXdHSro7DnHcdkhV0M=";
     };
     "virtual_character_ref.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/virtual_character_ref.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/virtual_character_ref.png";
       hash = "sha256-nKzg36HHXWRwGVW2fcyLLgqcLMf7fKSmXmKxF/GqCEM=";
     };
     "virtual_portrait.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/virtual_portrait.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/virtual_portrait.png";
       hash = "sha256-dug+WVk47d4h4oOx3LDvifOo0egVrkQfsOb/OMcbTos=";
     };
     "voice_demo.mp3" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/voice_demo.mp3";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/voice_demo.mp3";
       hash = "sha256-jPmdU9yDTYoRIn+EgfxcqARGJbxu22peTWRg5fpZ660=";
     };
     "vr_ad.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/vr_ad.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/vr_ad.png";
       hash = "sha256-bCRu0Pe6oazVS2XZyd6UHXfY5AvzsZvfEYntCoe/kns=";
     };
     "wan2.1_flf2v_720_f16_end_image.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/wan2.1_flf2v_720_f16_end_image.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/wan2.1_flf2v_720_f16_end_image.png";
       hash = "sha256-np9tFQ8tJmsykY79ojYe+0RcwZuLLTaEt3YDeZAFQ+0=";
     };
     "wan2.1_flf2v_720_f16_start_image.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/wan2.1_flf2v_720_f16_start_image.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/wan2.1_flf2v_720_f16_start_image.png";
       hash = "sha256-dVIU+MkteUFfrHdKbZc/mXon6xaaJ/pSxTvEciUwbaY=";
     };
     "wan2.1_fun_control_control_video.mp4" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/wan2.1_fun_control_control_video.mp4";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/wan2.1_fun_control_control_video.mp4";
       hash = "sha256-PyqGyxQWqBC6PMFGIp8ZFNDr165p9iAVZCqy0uEH4AM=";
     };
     "wan2.1_fun_control_start_frame.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/wan2.1_fun_control_start_frame.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/wan2.1_fun_control_start_frame.png";
       hash = "sha256-DiHMqxIiNQ6WwyUNc+nDyApiGoaVCiNm/5h3VdhpBW4=";
     };
     "wan2.1_fun_inp_end_image.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/wan2.1_fun_inp_end_image.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/wan2.1_fun_inp_end_image.png";
       hash = "sha256-TdiVih+atrSmFlYvRcQO9r5aws51Oq38a40tPRzSrUo=";
     };
     "wan2.1_fun_inp_start_image.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/wan2.1_fun_inp_start_image.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/wan2.1_fun_inp_start_image.png";
       hash = "sha256-rIhYvO4yn5eZc7D5gFlbTj8j2j5q2WQt7furNjzdUaE=";
     };
     "wan21_scail-input.mp4" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/wan21_scail-input.mp4";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/wan21_scail-input.mp4";
       hash = "sha256-NsZAmnOJyWxXCdFJBJNlKQ8nSzGIkJ2R4Hjxq1D6aTY=";
     };
     "wan22-animate-auto-character_replace-input.mp4" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/wan22-animate-auto-character_replace-input.mp4";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/wan22-animate-auto-character_replace-input.mp4";
       hash = "sha256-t5NaboIZrBKDHLnWe9jiXeeDrd4TfhGcGTXcxEJxDs8=";
     };
     "wan2_1_infinitetalk_audio.mp3" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/wan2_1_infinitetalk_audio.mp3";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/wan2_1_infinitetalk_audio.mp3";
       hash = "sha256-qKEDU7wBEITyoNfgKz7ToWWH2JOHW8lfo1V7QKXPK/w=";
     };
     "wan2_1_infinitetalk_first_frame.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/wan2_1_infinitetalk_first_frame.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/wan2_1_infinitetalk_first_frame.png";
       hash = "sha256-mHXhLMtcGyTNIN1dkwbYqxWUd0CCC/Lo4PIzZR2ntYU=";
     };
     "wan_dancer_reference_audio.mp3" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/wan_dancer_reference_audio.mp3";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/wan_dancer_reference_audio.mp3";
       hash = "sha256-rUAusmwlCwT5FID69mRtmTDNgNEoZxAKC14EVujeyVA=";
     };
     "warm_living_room.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/warm_living_room.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/warm_living_room.png";
       hash = "sha256-hRH0eSSoKbLOS7I9plinr9IjEuGMFc68jzh4wkvMIOU=";
     };
     "wasteland_merchant.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/wasteland_merchant.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/wasteland_merchant.png";
       hash = "sha256-McTP+neCZ54YHCtVzhud7YAAcyagIsX2+MwxVegBL5U=";
     };
     "watch_macro_shot.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/watch_macro_shot.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/watch_macro_shot.png";
       hash = "sha256-QyqhRhlx43C1f/pwGxNaAKXWdoXxn270obDcznLysLQ=";
     };
     "western_rider.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/western_rider.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/western_rider.png";
       hash = "sha256-2wQo0rl2+FYl5ykQR+0A2LB5Om2O/21MiM+4UVK/z/Q=";
     };
     "white-hotel-on-rocky-island.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/white-hotel-on-rocky-island.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/white-hotel-on-rocky-island.png";
       hash = "sha256-7GTeB8uarSF2ocIsNsrBdDbdUpJbkyjEG7PsyCgMRmw=";
     };
     "white_armored_warrior.mp4" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/white_armored_warrior.mp4";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/white_armored_warrior.mp4";
       hash = "sha256-VnCkayWz0IRMIP7S7IZmnTZeJS6W9M00r7k+IFJbJbI=";
     };
     "white_tiger.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/white_tiger.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/white_tiger.png";
       hash = "sha256-3U/5wEgWGHszmXULzS0v0PlAAJtzGVtFlKKV7kxw4fU=";
     };
     "wild_run.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/wild_run.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/wild_run.png";
       hash = "sha256-VjcPlAmIqEXi4dyZ1C5z69kNLbkL9Z2TAzHNH4XfPg0=";
     };
     "wind_woman.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/wind_woman.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/wind_woman.png";
       hash = "sha256-wh4HSFL49bIWXw0EqJlvER2LQpMd/rBYmf2ngjxkk/s=";
     };
     "wired_serenity_cyber_figure.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/wired_serenity_cyber_figure.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/wired_serenity_cyber_figure.png";
       hash = "sha256-VJjkYrRQt5m4P+7D7HUjgDfDVHlcnhLCDkGFbKXFbO4=";
     };
     "wireframe_dancer.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/wireframe_dancer.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/wireframe_dancer.png";
       hash = "sha256-OpP25pog63bHKEeN4BI8qCdu9AA7e5Vhai6txgRLsbI=";
     };
     "woman_behind_veil.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/woman_behind_veil.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/woman_behind_veil.png";
       hash = "sha256-Ebq7caXyPOQ/Uz/+2qOUC6tXZYXkTV1zJC8D48eCX5o=";
     };
     "woman_by_tram.mp4" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/woman_by_tram.mp4";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/woman_by_tram.mp4";
       hash = "sha256-zAE54vvMHBPhelXkZtfw3fdmYXLzCW1o0i8tniHZO6I=";
     };
     "woman_holding_face_oil.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/woman_holding_face_oil.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/woman_holding_face_oil.png";
       hash = "sha256-XcV5tKfFTYVB9npwCCrKY8FP/KTziV/PX3rW1+V5saI=";
     };
     "woman_holding_the_pipeapple.mp4" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/woman_holding_the_pipeapple.mp4";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/woman_holding_the_pipeapple.mp4";
       hash = "sha256-Rg5oOgGg6tJoX/pM4365C+bkjzDthY1mw78NV/Cjhwc=";
     };
     "woman_in_red.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/woman_in_red.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/woman_in_red.png";
       hash = "sha256-2LRwXUpaPjBEPZenpr22QZmSXha5CH8yrBV1QILkapQ=";
     };
     "woman_in_wheat_field.mp4" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/woman_in_wheat_field.mp4";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/woman_in_wheat_field.mp4";
       hash = "sha256-BODHxODqw8F8ETcsoAmcXly2NC1551gJJ3QlZq8FTAY=";
     };
     "woman_running_in_field.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/woman_running_in_field.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/woman_running_in_field.png";
       hash = "sha256-u9pQUTWOMZH8iew39H2CEI6KRAbt4UfXk4j7avQBxAA=";
     };
     "woman_walking.mp4" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/woman_walking.mp4";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/woman_walking.mp4";
       hash = "sha256-CzMTk/iGB+lsJiHYjXe77c8rLDZVhrCI5T0rT11aMXE=";
     };
     "woman_with_paper.mp4" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/woman_with_paper.mp4";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/woman_with_paper.mp4";
       hash = "sha256-fFB+Fr6qn+mLJ8JFj40x6T6dG3ek/hKEBb8KaXpgLsg=";
     };
     "woman_with_red_hat.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/woman_with_red_hat.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/woman_with_red_hat.png";
       hash = "sha256-LI3PVxo1FVwZvx2OgL5ePjDg5erlO0u6CiW1e/uzU7w=";
     };
     "woman_with_sunbeam.jpg" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/woman_with_sunbeam.jpg";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/woman_with_sunbeam.jpg";
       hash = "sha256-DCarPnniFu6fKDoFGE3VCQYB2VR9Dil+0LAvX2evbR4=";
     };
     "women_with_blue_orb.jpg" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/women_with_blue_orb.jpg";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/women_with_blue_orb.jpg";
       hash = "sha256-xtwTsjYi2354RNkG80ts7/o0UZBJShK454XK+aqhw20=";
     };
     "women_with_paper.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/women_with_paper.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/women_with_paper.png";
       hash = "sha256-ihT0/qeJpK3B5/ufSbWxTOz2q1p6sPkcgrj1ddRU6g4=";
     };
     "wooden_chair.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/wooden_chair.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/wooden_chair.png";
       hash = "sha256-QF8EFxGxOBdsVBamuHnwJac6+NnRUqCwlRkicz+KNpU=";
     };
     "wooden_doll.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/wooden_doll.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/wooden_doll.png";
       hash = "sha256-KxJyrP5CsGGPlG6Eg/BITaWa+GXexPXeXJRj2dYngKI=";
     };
     "wooden_doll_2_views.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/wooden_doll_2_views.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/wooden_doll_2_views.png";
       hash = "sha256-AilJ1wJyAkQ7IM9aWUZOlhP6ymKnChdc50lYO7FX+SE=";
     };
     "wooden_doll_back.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/wooden_doll_back.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/wooden_doll_back.png";
       hash = "sha256-wIpeUwIyD8S0P2OqzBB9g3vjTCXDz5DNXtizUXzPeIk=";
     };
     "wooden_doll_left.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/wooden_doll_left.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/wooden_doll_left.png";
       hash = "sha256-SjOrUtx9gO3NiVbKrig4q4GezxuRkCDtruD8hECTM7w=";
     };
     "wooden_facade_building.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/wooden_facade_building.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/wooden_facade_building.png";
       hash = "sha256-xz+ebhTGH0NM5TiGKT1QKoJYhqB6SiMPW895aPCIEbA=";
     };
     "x_robot.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/x_robot.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/x_robot.png";
       hash = "sha256-diNIzJ+bBZ+sEHXKdtNHGPM0D+LWUjx2Oatnnixhcng=";
     };
     "yellow_lens_girl.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/yellow_lens_girl.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/yellow_lens_girl.png";
       hash = "sha256-SRifpLAmZZSaX1h9NNzouDt8wSLsGagpNHSx/XWeAwQ=";
     };
     "young_baseball_player.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/young_baseball_player.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/young_baseball_player.png";
       hash = "sha256-1/ajROlYhON/EDmOzRLpK2PufCd8sQgcf9ZAMunMoIQ=";
     };
     "young_woman_portrait.png" = {
-      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/2b7f823136606344f0bccce249898d771b809aa1/input/young_woman_portrait.png";
+      url = "https://raw.githubusercontent.com/Comfy-Org/workflow_templates/4cd34a9a935e52e418c05fb299b248a11f5967b0/input/young_woman_portrait.png";
       hash = "sha256-VSQpjPjvM9EqG6BmfTXVGGqyDltCOPRfcTwFyTVJirA=";
     };
   };

--- a/nix/versions.nix
+++ b/nix/versions.nix
@@ -5,10 +5,10 @@
   };
 
   comfyui = {
-    version = "0.32.0";
-    releaseDate = "2026-08-11T21:56:20Z";
-    rev = "c2bcbecd82ec5ae66594340b395c24ef0217b238";
-    hash = "sha256-LlJHF/wEL8HhJAKw2DaxsoMltLpV3DtFWDlTW3AZZuI=";
+    version = "0.33.1";
+    releaseDate = "2026-08-13T22:18:34Z";
+    rev = "72865f4f27eaf5396f8f36370e0a2be3a9a090ee";
+    hash = "sha256-r6amApYXBjfE8+UvhiJ/7VcUibd4kd5i+JLPXxo8H9w=";
   };
 
   vendored = {
@@ -25,21 +25,21 @@
     };
 
     workflowTemplates = {
-      version = "0.11.39";
-      url = "https://files.pythonhosted.org/packages/c1/61/4c37dc382d5e1b5a264df06a01b36cf849c3ff89325da0ad8ae649b53305/comfyui_workflow_templates-0.11.39-py3-none-any.whl";
-      hash = "sha256-lvsG6cJMTYBzVw1/wdW4+hbBjomd8Lzf7NO4HGPoEgU=";
+      version = "0.11.41";
+      url = "https://files.pythonhosted.org/packages/65/ce/13f2fe0eb2079a7d1effe3cfe95b0b56a31c0f7e28bac77aedae5d99e29e/comfyui_workflow_templates-0.11.41-py3-none-any.whl";
+      hash = "sha256-1aolKqZsGWR1P5J0NniiFimtjI8BvoQ8cuA+BYisMKU=";
     };
 
     workflowTemplatesCore = {
-      version = "0.3.307";
-      url = "https://files.pythonhosted.org/packages/0f/b9/65b301dcb0a7b9c8e0bcc9e8852b6bd9c5bd4f491d77c84f030d57a9f6f7/comfyui_workflow_templates_core-0.3.307-py3-none-any.whl";
-      hash = "sha256-Jovz5ReQ+hrymj+46L/yECQa0G3QXIh3dOiAKR4lvO0=";
+      version = "0.3.312";
+      url = "https://files.pythonhosted.org/packages/c6/12/d1ef6c177e847d0291bbd6bf6fbb4440fb8df133b1bcae964c35d8237fdf/comfyui_workflow_templates_core-0.3.312-py3-none-any.whl";
+      hash = "sha256-22UM+Fac5TFhSs9IHD8+5l2gt0oj1Z4gZENICsgMXxQ=";
     };
 
     workflowTemplatesJson = {
-      version = "0.1.42";
-      url = "https://files.pythonhosted.org/packages/64/a3/f48c9377dde56498c4ce5aa7bd0c98a032f92bf3b562c555157518c8dbe9/comfyui_workflow_templates_json-0.1.42-py3-none-any.whl";
-      hash = "sha256-JCmC1l4cUcoD2JK8EAm7aEP0V+ffwMIK/mQ4dwt6FKM=";
+      version = "0.1.47";
+      url = "https://files.pythonhosted.org/packages/8f/96/996c53c15cd13d4641e848c0ba6142cf58235cf91e2eb67bee5a4b14bdf1/comfyui_workflow_templates_json-0.1.47-py3-none-any.whl";
+      hash = "sha256-mVAmaYATOsXwLZzep4TsV8pUgcZL18F7ZaWo2UX2/e0=";
     };
 
     workflowTemplatesMediaApi = {
@@ -67,9 +67,9 @@
     };
 
     workflowTemplatesMediaAssets01 = {
-      version = "0.1.26";
-      url = "https://files.pythonhosted.org/packages/06/86/276e31c9b08f985092fbfc9c9d4f5149a3f504e4a1e5e773b278cab03b1c/comfyui_workflow_templates_media_assets_01-0.1.26-py3-none-any.whl";
-      hash = "sha256-fY5iYge1r+v5Eg2PcAYjaj5H3srYupYYwumQ/43k5do=";
+      version = "0.1.28";
+      url = "https://files.pythonhosted.org/packages/03/9b/d06af3c2be67040704231720f2b69f9f91bf349d70b163c0c45b54694c85/comfyui_workflow_templates_media_assets_01-0.1.28-py3-none-any.whl";
+      hash = "sha256-hZE75UqqunKYKUgOIjlYcD5A3TS3vqIlKxX+d5cu+18=";
     };
 
     embeddedDocs = {
@@ -91,18 +91,18 @@
     # (issue #66), so prefer the platform wheels where they exist and keep the
     # any-wheel as the macOS fallback.
     comfyKitchen = {
-      version = "0.2.30";
+      version = "0.2.31";
       any = {
-        url = "https://files.pythonhosted.org/packages/dc/a4/ab676a2078663b09324b30f177e0b173f99f0ad54fac0465688f7327b511/comfy_kitchen-0.2.30-py3-none-any.whl";
-        hash = "sha256-883gS9M+cIOZfDN6I55M6SLPWRcxtTR85NRe9OP9PDk=";
+        url = "https://files.pythonhosted.org/packages/27/d1/e53410260b81610233cb56c2fac1a9f3d39887be3cbb983cd8baa6a07528/comfy_kitchen-0.2.31-py3-none-any.whl";
+        hash = "sha256-UReUbDDzCM/HO5wm9yOuORgwi9CQ5XqOrimEBpNKq9Y=";
       };
       linuxX86_64 = {
-        url = "https://files.pythonhosted.org/packages/b5/2b/250f5285bed699b85b3c2ee4280bcee399c43d54a785d3fa3c8a2b0e4dad/comfy_kitchen-0.2.30-cp312-abi3-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl";
-        hash = "sha256-2mBR36sAQKdWKBbGyh71OZ7pVBHFe40df3GDvCJEVK8=";
+        url = "https://files.pythonhosted.org/packages/db/5d/7df83ccb2b3fc4b9660dd337dcc56f7c65926318ae0303840a1e5b72493d/comfy_kitchen-0.2.31-cp312-abi3-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl";
+        hash = "sha256-18JSLmps3npzA+MNc5wFmJz0sKJGaE5JahKblQBV018=";
       };
       linuxAarch64 = {
-        url = "https://files.pythonhosted.org/packages/d9/75/c27bd577784addc47394d2f8b5d91a486ec2c3f992ac8c382cd4c4d43ce0/comfy_kitchen-0.2.30-cp312-abi3-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl";
-        hash = "sha256-v6bsOc7d2Y6q7kXb/H9oeLoUjW/Ve3YvVkamZrlsMpc=";
+        url = "https://files.pythonhosted.org/packages/fc/7c/bcabb37a3401163dfe6e61042206e44470072ee9088b4330518a2715f552/comfy_kitchen-0.2.31-cp312-abi3-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl";
+        hash = "sha256-eDNvMY181Rws8Ac3YN6MhKGk/Vy2gblIbLoT5l2zXzM=";
       };
     };
 


### PR DESCRIPTION
Routine upstream sync.

## Changes

- ComfyUI 0.32.0 → 0.33.1 (`72865f4`, 2026-08-13)
- comfyui-workflow-templates 0.11.39 → 0.11.41 (subpackages: core 0.3.312, json 0.1.47, media-assets-01 0.1.28; media-api/video/image/other were already at the required versions)
- comfy-kitchen 0.2.30 → 0.2.31 (all three wheels re-pinned)
- Template inputs regenerated: 11 new template files, 654 → 665 entries

Upstream requirements.txt delta between the tags is exactly the two lines above; frontend 1.48.7, embedded-docs 0.5.9, and comfy-aimdo 0.4.13 are unchanged. The one wired build patch (`comfyui-cpu-fallback.patch`) applies cleanly.

## Verification

- `nix build` (default) and `.#cuda` both green; ruff/nixfmt/shellcheck checks pass
- All wheel hashes independently re-derived from PyPI in review
- Live-tested the CUDA build on an RTX 4090: server up on 0.33.1 / torch 2.10.0+cu130, model downloader exercised end-to-end (real download to the correct folder, progress/list/folders endpoints, frontend JS served)

🤖 Generated with [Claude Code](https://claude.com/claude-code)