### PR TITLE
fix(rocm): fix torchvision ROCm version mismatch on NixOS with AMD GPUs

### DIFF
--- a/nix/packages.nix
+++ b/nix/packages.nix
@@ -234,6 +234,14 @@ let
 
   # NOTE: Some custom nodes (and some Python wheels) dlopen GUI-related libs at runtime
   # (e.g. OpenCV highgui / Qt platform plugins). Ensure common X11 libs are discoverable.
+  # Torch's bundled libs (libc10.so, libamdhip64.so.7, etc.) must appear before
+  # /run/opengl-driver/lib which may contain older ROCm libs (e.g. libamdhip64.so.6)
+  torchLibPath =
+    if (useCuda || useRocm) then
+      "${python.pkgs.torch}/${python.sitePackages}/torch/lib"
+    else
+      "";
+
   libPath = lib.makeLibraryPath [
     pkgs.stdenv.cc.cc.lib
     pkgs.glib
@@ -275,11 +283,13 @@ let
     else
       ''
         # Linux: Set LD_LIBRARY_PATH for dynamic libraries
-        export LD_LIBRARY_PATH="${libPath}''${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
+        # Torch's bundled libs must come first — /run/opengl-driver/lib may contain
+        # older ROCm libs (e.g. libamdhip64.so.6) that break torch's bundled ROCm 7.1
+        export LD_LIBRARY_PATH="${torchLibPath}${lib.optionalString (torchLibPath != "") ":"}${libPath}''${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
 
-        # Add NVIDIA driver libraries if available (NixOS)
+        # Add NVIDIA/AMD driver libraries if available (NixOS)
         if [[ -d "/run/opengl-driver/lib" ]]; then
-          export LD_LIBRARY_PATH="/run/opengl-driver/lib:$LD_LIBRARY_PATH"
+          export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:/run/opengl-driver/lib"
         fi
       '';
 

--- a/nix/python-overrides.nix
+++ b/nix/python-overrides.nix
@@ -387,7 +387,9 @@ lib.optionalAttrs useCuda {
     nativeBuildInputs = [ pkgs.autoPatchelfHook ];
     buildInputs = wheelBuildInputs ++ rocmLibs ++ [ final.torch ];
 
-    # Ignore torch libs (loaded via Python import)
+    # Torch libs live in a non-standard path (site-packages/torch/lib/) so
+    # autoPatchelf can't find them. We ignore them during patching and add
+    # the RPATH manually in postFixup so _C.so can find libc10.so at runtime.
     autoPatchelfIgnoreMissingDeps = [
       "libc10.so"
       "libc10_hip.so"
@@ -403,12 +405,18 @@ lib.optionalAttrs useCuda {
       "libMIOpen.so.1"
       "librocrand.so.1"
     ];
+    postFixup = ''
+      local torchLib="${final.torch}/${final.torch.pythonModule.sitePackages}/torch/lib"
+      for so in $out/${final.torch.pythonModule.sitePackages}/torchvision/*.so; do
+        ${pkgs.patchelf}/bin/patchelf --add-rpath "$torchLib" "$so"
+      done
+    '';
     propagatedBuildInputs = with final; [
       torch
       numpy
       pillow
     ];
-    pythonImportsCheck = [ ];
+    pythonImportsCheck = [ "torchvision" ];
     doCheck = false;
     meta = {
       description = "TorchVision with ROCm (pre-built wheel)";


### PR DESCRIPTION
This PR is based on #47, updates it to the latest commit and applies the fix only for ROCm. The issues #47 and #46 describe still occur for me on the latest commit (v0.34.0, 9c0c693afe7e355b69fdc73dc0b28a628426a814).

Tested on NixOS 26.11 unstable, kernel 7.2.0 with an RX 9070 XT (GFX1201).

Fixes #46, `nix run github:utensils/comfyui-nix#rocm -- --enable-manager` runs without issue.